### PR TITLE
Imports missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import {
   createImageUrlBuilder,
   createPortableTextComponent,
   createPreviewSubscriptionHook,
+  createCurrentUserHook,
 } from 'next-sanity'
 
 const config = {


### PR DESCRIPTION
The example was using createCurrentUserHook() but hadn't imported it.