### PR TITLE
Add missing withCredentials to picosanity type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface ProjectConfig {
 export interface ClientConfig extends ProjectConfig {
   token?: string
   useCdn?: boolean
+  withCredentials?: boolean
 }
 
 export interface CurrentUser {


### PR DESCRIPTION
The types for the client doesn't include the withCredentials property that picosanity defines at https://github.com/rexxars/picosanity/blob/main/client.d.ts#L9