### PR TITLE
Foundations for apiVersion in createPreviewSubscriptionHook

### DIFF
--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -17,6 +17,7 @@ export function createPreviewSubscriptionHook({
   projectId,
   dataset,
   documentLimit = 3000,
+  apiVersion,
 }: ProjectConfig & {documentLimit?: number}) {
   // Only construct/setup the store when `getStore()` is called
   let store: Promise<GroqStore>
@@ -43,6 +44,7 @@ export function createPreviewSubscriptionHook({
           projectId,
           dataset,
           documentLimit,
+          apiVersion,
           listen: true,
           overlayDrafts: true,
           subscriptionThrottleMs: 10,


### PR DESCRIPTION
This PR lays the foundation for supporting `apiVersion` in `createPreviewSubscriptionHook`. Still doesn't have any effect as  `groq-js` isn't up to date with the specification. Feel free to close this PR if API versioning never becomes a thing with this hook.

Stems from this Slack thread: https://sanity-io-land.slack.com/archives/C013NG0UF0B/p1618038372004900