### PR TITLE
docs: update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A minimal example for a blog post template using the schema from from the Sanity
 import ErrorPage from 'next/error'
 import {useRouter} from 'next/router'
 import {groq} from 'next-sanity'
-import {getClient, usePreviewSubscription, urlFor, PortableText} from '../../lib/sanity'
+import {usePreviewSubscription, urlFor, PortableText} from '../../lib/sanity'
 import {getClient} from '../../lib/sanity.server'
 
 const postQuery = groq`


### PR DESCRIPTION
With the 0.2.0 release, the addition of a second `getClient` import triggers an error:

    Syntax error: Identifier 'getClient' has already been declared

Remove from the example to help the unsuspecting.