### PR TITLE
Export SubscriptionOptions

### DIFF
--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -7,7 +7,7 @@ import {getAborter} from './aborter'
 
 const EMPTY_PARAMS = {}
 
-interface SubscriptionOptions<R = any> {
+export interface SubscriptionOptions<R = any> {
   enabled?: boolean
   params?: Record<string, unknown>
   initialData?: R


### PR DESCRIPTION
Sometimes TypeScript will complain about not being able to name an exported variable. exporting subscription options fixes this.

Example:
```typescript
const usePreviewSubscription = createPreviewSubscriptionHook(config);
```

Error message
> Type error: Exported variable 'usePreviewSubscription' has or is using name 'SubscriptionOptions' from external module "./node_modules/next-sanity/dist/useSubscription" but cannot be named.