### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ All notable changes will be documented in this file.
 
 ### BREAKING
 
+- Upgraded `@sanity/client` to `v3`, see its [CHANGELOG](https://github.com/sanity-io/client/blob/main/CHANGELOG.md#300) for details.
 - `createPortableTextComponent` is removed.
 - `createImageUrlBuilder` is removed.
-  See README for migration instructions.
+
+See the [README](https://github.com/sanity-io/next-sanity#from-v04) for migration instructions.
 
 ## 0.4.0 - 2021-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes will be documented in this file.
 
+## 0.5.0 - 2022-02-16
+
+### Features
+
+- Upgraded `@sanity/groq-store` to `v0.3.0` which includes a new beta of `groq-js` that improves performance, especially when using projections.
+
+### BREAKING
+
+- `createPortableTextComponent` is removed.
+- `createImageUrlBuilder` is removed.
+  See README for migration instructions.
+
 ## 0.4.0 - 2021-08-11
 
 ### BREAKING

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "coverage": "tsdx test --coverage"
   },
   "dependencies": {
-    "@sanity/client": "^2.14.0",
-    "@sanity/groq-store": "^0.2.1",
-    "groq": "^2.14.0"
+    "@sanity/client": "^2.23.2",
+    "@sanity/groq-store": "^0.3.0",
+    "groq": "^2.15.0"
   },
   "devDependencies": {
     "@async-fn/jest": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coverage": "tsdx test --coverage"
   },
   "dependencies": {
-    "@sanity/client": "^2.23.2",
+    "@sanity/client": "^3.0.6",
     "@sanity/groq-store": "^0.3.0",
     "groq": "^2.15.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-sanity",
   "description": "Sanity.io toolkit for Next.js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Sanity.io <hello@sanity.io>",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
Prepping the `v0.5.0` release, which includes the move to the new `groq-js` beta 🙂 