### PR TITLE
fix: re-export `@sanity/client` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes will be documented in this file.
 
+## 0.5.2
+
+### Fixes
+
+- Exports the `Aborter` interface used in `AbortController` to support stricter TypeScript setups.
+- Allows stricter TypeScript setups by re-exporting `SanityClient` and `ClientConfig` from `@sanity/client`
+- Bumps `@sanity/client` to `v3.3.0`, `@sanity/groq-store` to `v0.3.1` and `groq` to `v2.29.3`
+- Typo in readme (#44)
+
 ## 0.5.1 - 2022-03-04
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "coverage": "tsdx test --coverage"
   },
   "dependencies": {
-    "@sanity/client": "^3.0.6",
-    "@sanity/groq-store": "^0.3.0",
-    "groq": "^2.15.0"
+    "@sanity/client": "^3.3.0",
+    "@sanity/groq-store": "^0.3.1",
+    "groq": "^2.29.3"
   },
   "devDependencies": {
     "@async-fn/jest": "^1.5.3",
@@ -46,8 +46,8 @@
     "react": ">=17.0.2",
     "react-dom": "^17.0.2",
     "tsdx": "^0.14.1",
-    "tslib": "^2.3.0",
-    "typescript": "^4.3.5"
+    "tslib": "^2.3.1",
+    "typescript": "^4.6.3"
   },
   "peerDependencies": {
     "react": ">=16.3.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import sanityClient from '@sanity/client'
-import {ClientConfig} from './types'
+import type {ClientConfig, SanityClient} from '@sanity/client'
 
-export function createClient(config: ClientConfig) {
+export function createClient(config: ClientConfig): SanityClient {
   return sanityClient(config)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
+import type {
+  ClientConfig as ClientConfigForExport,
+  SanityClient as SanityClientForExport,
+} from '@sanity/client'
+import type {Aborter as AborterForExport} from './aborter'
+
+// Re-export to support --isolatedMode and other strict mode features
+export type ClientConfig = ClientConfigForExport
+export type SanityClient = SanityClientForExport
+export type Aborter = AborterForExport
+
 export * from './types'
-export {createClient} from './client'
+export * from './client'
 export {createCurrentUserHook} from './currentUser'
 export {createPreviewSubscriptionHook} from './useSubscription'
 export {default as groq} from 'groq'

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,6 @@ export interface ProjectConfig {
   dataset: string
 }
 
-export interface ClientConfig extends ProjectConfig {
-  token?: string
-  useCdn?: boolean
-  withCredentials?: boolean
-  apiVersion?: string
-}
-
 export interface CurrentUser {
   id: string
   name: string


### PR DESCRIPTION
Published a beta of this PR, you can test it using `npm i next-sanity@beta`.