### PR TITLE
Allow groqStore listen param to be overridden in configuration

### DIFF
--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -21,7 +21,8 @@ export function createPreviewSubscriptionHook({
   token,
   EventSource,
   documentLimit = 3000,
-}: ProjectConfig & {documentLimit?: number}) {
+  listen = true,
+}: ProjectConfig & {documentLimit?: number, listen?: boolean}) {
   // Only construct/setup the store when `getStore()` is called
   let store: Promise<GroqStore>
 
@@ -58,7 +59,7 @@ export function createPreviewSubscriptionHook({
           documentLimit,
           token,
           EventSource,
-          listen: true,
+          listen,
           overlayDrafts: true,
           subscriptionThrottleMs: 10,
         })


### PR DESCRIPTION
Adds an optional parameter to `createPreviewSubscriptionHook` that can be used to override the `listen` config for the  `groqStore`.

We're having trouble using the live preview feature on some pages that are very slow to re-render and would like the ability to reduce functionality to a "preview on reload", while still maintaining draft overlays. 