### PR TITLE
fix: export the subscription options to avoid ts errors

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,11 @@ export interface CurrentUser {
   name: string
   profileImage?: string
 }
+
+export type Params = Record<string, unknown>
+
+export interface SubscriptionOptions<R = any> {
+  enabled?: boolean
+  params?: Params
+  initialData?: R
+}

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -3,16 +3,9 @@ import {useEffect, useMemo, useState} from 'react'
 
 import {Aborter, getAborter} from './aborter'
 import {getCurrentUser} from './currentUser'
-import {ProjectConfig} from './types'
+import {Params, ProjectConfig, SubscriptionOptions} from './types'
 
 const EMPTY_PARAMS = {}
-
-export type Params = Record<string, unknown>
-export interface SubscriptionOptions<R = any> {
-  enabled?: boolean
-  params?: Params
-  initialData?: R
-}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function createPreviewSubscriptionHook({


### PR DESCRIPTION
The SubscriptionOptions interface not being exported causes an error with Typescript.

Here's a link to a github issue describing the issue: 
https://github.com/microsoft/TypeScript/issues/5711

I moved the types to the ./types.ts file which has all of it's types exported from index.ts