### PR TITLE
fix: expand supported next version range to allow v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "next": "^12",
+        "next": "^12 || ^13",
         "react": "^16.3 || ^17 || ^18",
         "sanity": "dev-preview",
         "styled-components": "^5.2"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "next": "^12",
+    "next": "^12 || ^13",
     "react": "^16.3 || ^17 || ^18",
     "sanity": "dev-preview",
     "styled-components": "^5.2"


### PR DESCRIPTION
Next v13 was released today, and things seems to work fine, so we should expand the version range to allow for it.
