### PR TITLE
feat: add support for fetching subset of dataset by type

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": ["main", {"name": "preview-kit", "prerelease": true}]
+  "branches": ["main", {"name": "preview-kit", "prerelease": true}, {"name": "add-type-allowlist", "prerelease": true}]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.0-add-type-allowlist.1](https://github.com/sanity-io/next-sanity/compare/v1.0.9...v1.1.0-add-type-allowlist.1) (2022-11-14)
+
+### Features
+
+- add support for fetching subset of dataset by type ([8416e74](https://github.com/sanity-io/next-sanity/commit/8416e74a47bc4cd9a0ef8420228941a178c198ea))
+
+### Bug Fixes
+
+- **deps:** update dependency @sanity/groq-store to ^1.0.4 (main) ([#146](https://github.com/sanity-io/next-sanity/issues/146)) ([5043b01](https://github.com/sanity-io/next-sanity/commit/5043b011b0e0b290f01f763842b5ffae725271ce))
+
 ## [1.0.9](https://github.com/sanity-io/next-sanity/compare/v1.0.8...v1.0.9) (2022-11-07)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ export const config = {
    * You might need this if you host the preview on a different url than Sanity Studio
    */
   token: '<sanity access token>',
-  EventSource: /* provide your own event source implementation. Required in browsers to support the above token parameter. */
+  EventSource:
+    EventSourcePolyfill /* provide your own event source implementation. Required in browsers to support the above token parameter. */,
+
+  // Optional allow list filter for document types. You can use this to limit the amount of documents by declaring the types you want to sync. Note that since you're fetching a subset of your dataset, queries that works against your Content Lake might not work against the local groq-store.
+  includeTypes: ['page', 'product', 'sanity.imageAsset'],
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
+        "@sanity/groq-store": "^1.1.0",
         "groq": "^2.33.2"
       },
       "devDependencies": {
@@ -4603,9 +4603,9 @@
       "dev": true
     },
     "node_modules/@sanity/groq-store": {
-      "version": "1.1.0-add-type-allowlist.1",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
-      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0.tgz",
+      "integrity": "sha512-D63l/5CvKe4SXbLEWj3+eV7WvQMj1udQA7SjO8WWnrowegS1bPN2T2dcoIexCJYlVSbWEmfFNaBkM3bdFcyEbA==",
       "dependencies": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",
@@ -25292,9 +25292,9 @@
       "dev": true
     },
     "@sanity/groq-store": {
-      "version": "1.1.0-add-type-allowlist.1",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
-      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0.tgz",
+      "integrity": "sha512-D63l/5CvKe4SXbLEWj3+eV7WvQMj1udQA7SjO8WWnrowegS1bPN2T2dcoIexCJYlVSbWEmfFNaBkM3bdFcyEbA==",
       "requires": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^3.4.1",
-        "@sanity/groq-store": "^1.0.4",
+        "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
         "groq": "^2.33.2"
       },
       "devDependencies": {
@@ -4603,9 +4603,9 @@
       "dev": true
     },
     "node_modules/@sanity/groq-store": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.0.4.tgz",
-      "integrity": "sha512-/VkUkTR3/xVIcFUrfxSm6NdPCgXg8MURNd8K7ftdRonNGh/rOZtTcvqj24mJueZhuoy+843himF3nOleMtuyrA==",
+      "version": "1.1.0-add-type-allowlist.1",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
+      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
       "dependencies": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",
@@ -25292,9 +25292,9 @@
       "dev": true
     },
     "@sanity/groq-store": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.0.4.tgz",
-      "integrity": "sha512-/VkUkTR3/xVIcFUrfxSm6NdPCgXg8MURNd8K7ftdRonNGh/rOZtTcvqj24mJueZhuoy+843himF3nOleMtuyrA==",
+      "version": "1.1.0-add-type-allowlist.1",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
+      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
       "requires": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-sanity",
-  "version": "1.0.9",
+  "version": "1.1.0-add-type-allowlist.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-sanity",
-      "version": "1.0.9",
+      "version": "1.1.0-add-type-allowlist.1",
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@sanity/client": "^3.4.1",
-    "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
+    "@sanity/groq-store": "^1.1.0",
     "groq": "^2.33.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@sanity/client": "^3.4.1",
-    "@sanity/groq-store": "^1.0.4",
+    "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
     "groq": "^2.33.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-sanity",
-  "version": "1.0.9",
+  "version": "1.1.0-add-type-allowlist.1",
   "description": "Sanity.io toolkit for Next.js",
   "keywords": [
     "sanity",

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -15,8 +15,8 @@ export function createPreviewSubscriptionHook({
   token,
   EventSource,
   documentLimit = 3000,
-  allowTypes,
-}: ProjectConfig & {documentLimit?: number; allowTypes?: string[]}) {
+  includeTypes,
+}: ProjectConfig & {documentLimit?: number; includeTypes?: string[]}) {
   // Only construct/setup the store when `getStore()` is called
   let store: Promise<GroqStore>
 
@@ -51,7 +51,7 @@ export function createPreviewSubscriptionHook({
           projectId,
           dataset,
           documentLimit,
-          allowTypes,
+          includeTypes,
           token,
           EventSource,
           listen: true,

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -15,7 +15,8 @@ export function createPreviewSubscriptionHook({
   token,
   EventSource,
   documentLimit = 3000,
-}: ProjectConfig & {documentLimit?: number}) {
+  allowTypes,
+}: ProjectConfig & {documentLimit?: number; allowTypes?: string[]}) {
   // Only construct/setup the store when `getStore()` is called
   let store: Promise<GroqStore>
 
@@ -50,6 +51,7 @@ export function createPreviewSubscriptionHook({
           projectId,
           dataset,
           documentLimit,
+          allowTypes,
           token,
           EventSource,
           listen: true,


### PR DESCRIPTION
Exposes the `allowTypes` option that's introduced in a prerelease of `@sanity/groq-store`: https://github.com/sanity-io/groq-store/pull/2

Install it using `npm i --save-exact next-sanity@add-type-allowlist`.
And in `createPreviewSubscriptionHook` you can now set the `allowTypes` option:

```tsx
import {createPreviewSubscriptionHook} from 'next-sanity'
const useQuerySubscription = createPreviewSubscriptionHook({
  /* ... */
  allowTypes: ['post', 'author', 'sanity.imageAsset'],
})
```

To quickly list types in a dataset run this groq query in `@sanity/vision`, with the `apiVersion` set to `vX`:
```groq
array::unique(*._type)
```