### PR TITLE
fix: remove tailwind SVG workaround

### DIFF
--- a/src/studio/NextStudio.tsx
+++ b/src/studio/NextStudio.tsx
@@ -2,7 +2,7 @@ import {memo} from 'react'
 import {type StudioProps, Studio} from 'sanity'
 
 import {NextStudioClientOnly} from './NextStudioClientOnly'
-import {type NextStudioLayoutProps, NextStudioLayout} from './NextStudioLayout'
+import {NextStudioLayout} from './NextStudioLayout'
 import {type NextStudioLoadingProps, NextStudioLoading} from './NextStudioLoading'
 
 export type {NextStudioLoadingProps}
@@ -14,12 +14,6 @@ export type {NextStudioLoadingProps}
 /** @beta */
 export interface NextStudioProps extends StudioProps {
   children?: React.ReactNode
-  /**
-   * Apply fix with SVG icon centering that happens if TailwindCSS is loaded
-   * @defaultValue true
-   * @alpha
-   */
-  unstable__tailwindSvgFix?: NextStudioLayoutProps['unstable__tailwindSvgFix']
   /**
    * Render the <noscript> tag
    * @defaultValue true
@@ -34,7 +28,6 @@ export interface NextStudioProps extends StudioProps {
 const NextStudioComponent = ({
   children,
   config,
-  unstable__tailwindSvgFix = true,
   unstable__noScript,
   scheme,
   ...props
@@ -48,11 +41,7 @@ const NextStudioComponent = ({
       />
     }
   >
-    <NextStudioLayout
-      config={config}
-      scheme={scheme}
-      unstable__tailwindSvgFix={unstable__tailwindSvgFix}
-    >
+    <NextStudioLayout config={config} scheme={scheme}>
       {children || <Studio config={config} scheme={scheme} unstable_globalStyles {...props} />}
     </NextStudioLayout>
   </NextStudioClientOnly>

--- a/src/studio/NextStudioLayout.tsx
+++ b/src/studio/NextStudioLayout.tsx
@@ -1,22 +1,16 @@
 /* eslint-disable camelcase */
 import {memo} from 'react'
 import type {StudioProps} from 'sanity'
-import styled, {css} from 'styled-components'
+import styled from 'styled-components'
 
 import {useTheme} from './useTheme'
 
 /** @alpha */
 export interface NextStudioLayoutProps extends Pick<StudioProps, 'config' | 'scheme'> {
   children: React.ReactNode
-  /**
-   * Apply fix with SVG icon centering that happens if TailwindCSS is loaded
-   * @defaultValue true
-   */
-  unstable__tailwindSvgFix?: boolean
 }
 
 type LayoutProps = {
-  $unstable__tailwindSvgFix: NextStudioLayoutProps['unstable__tailwindSvgFix']
   $bg: string
   $fontFamily: string
 }
@@ -28,30 +22,18 @@ const Layout = styled.div<LayoutProps>`
   overscroll-behavior: none;
   -webkit-font-smoothing: antialiased;
   overflow: auto;
-
-  ${({$unstable__tailwindSvgFix}: any) =>
-    $unstable__tailwindSvgFix
-      ? css`
-          /* override tailwind reset */
-          *:not([data-ui='Popover__arrow']):not([data-ui='Tooltip__arrow']) > svg {
-            display: inline;
-          }
-        `
-      : ''}
 `
 
 const NextStudioLayoutComponent = ({
   children,
   config,
   scheme = 'light',
-  unstable__tailwindSvgFix = true,
 }: NextStudioLayoutProps) => {
   const theme = useTheme(config)
 
   return (
     <Layout
       data-ui="NextStudioLayout"
-      $unstable__tailwindSvgFix={unstable__tailwindSvgFix}
       $fontFamily={theme.fonts.text.family}
       $bg={theme.color[scheme].default.base.bg}
     >


### PR DESCRIPTION
The fix is brittle, it's better to add `display: inline` where necessary in `@sanity/ui` itself.

Related to https://github.com/sanity-io/ui/pull/1022