### PR TITLE
fix(deps): correct peer dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,13 +182,13 @@
     "url-loader": "^4.1.1"
   },
   "peerDependencies": {
-    "@sanity/icons": "*",
-    "@sanity/types": "*",
-    "@sanity/ui": "*",
+    "@sanity/icons": "^2",
+    "@sanity/types": "^3",
+    "@sanity/ui": "^1",
     "next": "^13",
     "react": "^18",
-    "sanity": "dev-preview || ^3",
-    "styled-components": "*"
+    "sanity": "^3",
+    "styled-components": "^5.2"
   },
   "peerDependenciesMeta": {
     "@sanity/icons": {


### PR DESCRIPTION
This changes the peer dependency versions to use explicit latest major versions.

With the exception of `styled-components` which is a `^5.2` peer dependency of the `sanity` package.