### PR TITLE
docs: add new starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ export default async function IndexPage() {
 ### Starters
 
 - [A Next.js Blog with a Native Authoring Experience](https://github.com/sanity-io/nextjs-blog-cms-sanity-v3)
+- [A multi-country ecommerce template built with Commerce Layer and Next.js](https://github.com/commercelayer/commercelayer-sanity-template)
 
 ### Limits
 


### PR DESCRIPTION
Not sure if this is acceptable since the README doesn't mention any process for additions, but please let me know if that section isn't meant to include more starters.

This PR adds the [commercelayer-sanity-template](https://github.com/commercelayer/commercelayer-sanity-template) that now supports Sanity studio v3 and `next-sanity`.