### PR TITLE
Add separate function for parsing body in App Router

### DIFF
--- a/src/webhook/index.ts
+++ b/src/webhook/index.ts
@@ -1,2 +1,3 @@
 export * from './config'
 export * from './parseBody'
+export * from './parseAppBody'


### PR DESCRIPTION
When NextRequest type is added in parseBody function, it is hard to differentiate between NextRequest and NextApiRequest. It cannot be done using `req instanceof NextRequest` because it returns `false` even the req type is NextRequest.

`app/api/webhooks/sanity/route.ts`
```js
import { NextRequest } from 'next/server'
import { parseBody } from 'next-sanity/webhook'

export async function POST(req: NextRequest) {
  console.log(req instanceof NextRequest) // return false
  const { body, isValidSignature } = await parseBody(req, process.env.SECRET) // TypeError
  ...
  return NextResponse.json({ isNextRequest: req instanceof NextRequest })
}
```
`parseBody.ts`
```js
...
let body
if (req instanceof NextRequest) { // always return false
  body = JSON.stringify(await req.json())
} else {
  body = await readBody(req) // not compatible with NextRequest causing TypeError
}
...
```
I think it is better to have separate function for parsing body in the App Router route handler. Then we can use the new function to parse body in route handler like this below.

`app/api/webhooks/sanity/route.ts`
```js
import { NextRequest, NextResponse } from 'next/server'
import { parseAppBody } from 'next-sanity/webhook'

export async function POST(req: NextRequest) {
  const { body, isValidSignature } = await parseAppBody(req, process.env.SECRET)
  if (!isValidSignature) {
      return (
        NextResponse.json({
          message: 'Invalid signature'
        }),
        {
          status: 401,
          headers: {
            'Content-Type': 'application/json',
          },
        }
      )
    }
  // Do something like revalidation
  ...
}
```