### PR TITLE
Add separate function for parsing body in App Router

### DIFF
--- a/src/webhook/index.ts
+++ b/src/webhook/index.ts
@@ -1,2 +1,3 @@
 export * from './config'
+export * from './parseAppBody'
 export * from './parseBody'

--- a/src/webhook/parseAppBody.ts
+++ b/src/webhook/parseAppBody.ts
@@ -1,14 +1,12 @@
 import type {SanityDocument} from '@sanity/types'
 import sanityWebhook from '@sanity/webhook'
-import type {NextApiRequest} from 'next'
+import {NextRequest} from 'next/server'
 
 // As `@sanity/webhook` isn't shipping ESM, extracting from the default export have the best ecosystem support
 const {isValidSignature, SIGNATURE_HEADER_NAME} = sanityWebhook
 
-import {_readBody as readBody} from './readBody'
-
 /** @public */
-export type ParseBody = {
+export type ParseAppBody = {
   /**
    * If a secret is given then it returns a boolean. If no secret is provided then no validation is done on the signature, and it'll return `null`
    */
@@ -20,17 +18,14 @@ export type ParseBody = {
  * without worrying about getting stale data.
  * @public
  */
-export async function parseBody(
-  req: NextApiRequest,
+export async function parseAppBody(
+  req: NextRequest,
   secret?: string,
   waitForContentLakeEventualConsistency: boolean = true
-): Promise<ParseBody> {
-  let signature = req.headers[SIGNATURE_HEADER_NAME]!
-  if (Array.isArray(signature)) {
-    signature = signature[0]
-  }
+): Promise<ParseAppBody> {
+  const signature = req.headers.get(SIGNATURE_HEADER_NAME)!
 
-  const body = await readBody(req)
+  const body = JSON.stringify(await req.json())
   const validSignature = secret ? isValidSignature(body, signature, secret.trim()) : null
 
   if (validSignature !== false && waitForContentLakeEventualConsistency) {


### PR DESCRIPTION
When NextRequest type is added in parseBody function, it is hard to differentiate between NextRequest and NextApiRequest. It cannot be done using `req instanceof NextRequest` because it returns `false` even the req type is NextRequest.

`app/api/webhooks/sanity/route.ts`
```js
import { NextRequest } from 'next/server'
import { parseBody } from 'next-sanity/webhook'

export async function POST(req: NextRequest) {
  console.log(req instanceof NextRequest) // return false
  const { body, isValidSignature } = await parseBody(req, process.env.SECRET) // TypeError
  ...
  return NextResponse.json({ isNextRequest: req instanceof NextRequest })
}
```
`parseBody.ts`
```js
...
let body
if (req instanceof NextRequest) { // always return false
  body = JSON.stringify(await req.json())
} else {
  body = await readBody(req) // not compatible with NextRequest causing TypeError
}
...
```
I think it is better to have separate function for parsing body in the App Router route handler. Then we can use the new function to parse body in route handler like this below.

`app/api/webhooks/sanity/route.ts`
```js
import { NextRequest, NextResponse } from 'next/server'
import { parseAppBody } from 'next-sanity/webhook'

export async function POST(req: NextRequest) {
  const { body, isValidSignature } = await parseAppBody(req, process.env.SECRET)
  if (!isValidSignature) {
      return (
        NextResponse.json({
          message: 'Invalid signature'
        }),
        {
          status: 401,
          headers: {
            'Content-Type': 'application/json',
          },
        }
      )
    }
  // Do something like revalidation
  ...
}
```