### PR TITLE
docs: add missing export in client.ts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID // "pv8y60vp"
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET // "production"
 const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2023-05-03'
 
-const client = createClient({
+export const client = createClient({
   projectId,
   dataset,
   apiVersion, // https://www.sanity.io/docs/api-versioning


### PR DESCRIPTION
The example for the client.ts file is missing the export for the client.