### PR TITLE
docs: next revalidate should be inside an object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ TODO
 tsconfig.tsbuildinfo
 .vercel
 .vscode
+.env*.local

--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ type HomePageProps = {
 
 export async function HomeLayout({children}) {
   const home = await client.fetch<HomePageProps>(`*[_id == "home"][0]{...,navItems[]->}`,
-    next: {
+    {next: {
       revalidate: 3600 // look for updates to revalidate cache every hour
-    }
+    }}
   })
 
   return (


### PR DESCRIPTION
Updated the code sample for time based revalidation docs to be passed a second argument as an object with the next property inside it. Previously it was shown to be passing the next property directly, which was an error.