### PR TITLE
feat!: add support for Next.js 14 viewport object

### DIFF
--- a/app/studio/[[...tool]]/page.tsx
+++ b/app/studio/[[...tool]]/page.tsx
@@ -3,6 +3,7 @@ import Studio from './Studio'
 export const dynamic = 'force-static'
 
 export {metadata} from 'src/studio/metadata'
+export {viewport} from 'src/studio/viewport'
 
 export default function StudioPage() {
   return <Studio />

--- a/package.json
+++ b/package.json
@@ -101,6 +101,17 @@
       "import": "./dist/studio/metadata.js",
       "default": "./dist/studio/metadata.js"
     },
+    "./studio/viewport": {
+      "types": "./dist/studio/viewport.d.ts",
+      "source": "./src/studio/viewport.ts",
+      "require": "./dist/studio/viewport.cjs",
+      "node": {
+        "module": "./dist/studio/viewport.js",
+        "import": "./dist/studio/viewport.cjs.js"
+      },
+      "import": "./dist/studio/viewport.js",
+      "default": "./dist/studio/viewport.js"
+    },
     "./webhook": {
       "types": "./dist/webhook.d.ts",
       "source": "./src/webhook/index.ts",

--- a/src/studio/metadata.ts
+++ b/src/studio/metadata.ts
@@ -37,8 +37,6 @@ import type {Metadata} from 'next'
  * @public
  */
 export const metadata = {
-  // Studio implements display cutouts CSS (The iPhone Notch ™ ) and needs `viewport-fit=covered` for it to work correctly
-  viewport: 'width=device-width,initial-scale=1,viewport-fit=cover' as const,
   referrer: 'same-origin' as const,
   robots: 'noindex' as const,
 } satisfies Metadata

--- a/src/studio/viewport.ts
+++ b/src/studio/viewport.ts
@@ -1,0 +1,26 @@
+import type {Viewport} from 'next'
+
+/**
+ * In Next 13 appDir mode (`/app/studio/[[...index]]/page.tsx`):
+ * ```tsx
+ * // If you don't want to change any defaults you can just re-export the viewport config directly:
+ * export {viewport} from 'next-sanity/studio'
+ *
+ * // To customize the viewport config, spread it on the export:
+ * import {viewport as studioViewport} from 'next-sanity/studio'
+ * import type { Viewport } from 'next'
+ *
+ * export const viewport: Viewport = {
+ *   ...studioViewport,
+ *   // Overrides the viewport to resize behavior
+ *   interactiveWidget: 'resizes-content'
+ * })
+ * ```
+ * @public
+ */
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  // Studio implements display cutouts CSS (The iPhone Notch ™ ) and needs `viewport-fit=covered` for it to work correctly
+  viewportFit: 'cover',
+} satisfies Viewport


### PR DESCRIPTION
With Next.js 14 the `viewport` property has been removed from the metadata API and should now be exported as a separate object: https://nextjs.org/docs/app/api-reference/functions/generate-viewport

<img width="1152" alt="Screen Shot 2023-10-27 at 5 11 59 PM" src="https://github.com/sanity-io/next-sanity/assets/1009069/69ea01fe-4f88-41da-a71d-b0531ae5d17e">


This adds a default `viewport` object that can be used just like the existing `metadata` object.

This is a breaking change since it removes the `viewport` property from the `metadata` export. Next will [set defaults for width and initialScale](https://nextjs.org/docs/app/api-reference/functions/generate-viewport#width-initialscale-and-maximumscale) but this still means that a project running Next 13.x would loose the `viewport-fit` configuration when updating to this change.

Not sure how you want to handle backwards compatibility here; I'm open to make changes as needed to this PR. 😊  