### PR TITLE
fix: add missing viewport type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,9 @@
       "studio/metadata": [
         "./dist/studio/metadata.d.ts"
       ],
+      "studio/viewport": [
+        "./dist/studio/viewport.d.ts"
+      ],
       "webhook": [
         "./dist/webhook.d.ts"
       ]


### PR DESCRIPTION
In #718, I forgot to add the new viewport file to `typesVersions` which means next-sanity 6.0.0 doesn't build properly when using TypeScript atm:

![Screen Shot 2023-11-06 at 7 58 40 AM](https://github.com/sanity-io/next-sanity/assets/1009069/732be7bf-190c-4a9a-9479-2da2b4602724)
