### PR TITLE
fix(deps): downgrade webhooks package to solve engines warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,18 @@
       "dependencies": {
         "@sanity/client": "^6.12.1",
         "@sanity/preview-kit": "5.0.17",
-        "@sanity/webhook": "4.0.1",
+        "@sanity/webhook": "4.0.0",
         "groq": "^3.19"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^14.1.0",
         "@next/eslint-plugin-next": "14.1.0",
         "@rollup/plugin-terser": "^0.4.4",
+        "@sanity/browserslist-config": "^1.0.0",
         "@sanity/eslint-config-studio": "^3.0.1",
         "@sanity/image-url": "^1.0.2",
         "@sanity/overlays": "2.3.8",
-        "@sanity/pkg-utils": "^4.1.0",
+        "@sanity/pkg-utils": "^4.1.1",
         "@sanity/ui": "^2.0.1",
         "@sanity/vision": "3.26.1",
         "@types/react": "^18.2.48",
@@ -4840,13 +4841,13 @@
       }
     },
     "node_modules/@sanity/pkg-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-4.1.0.tgz",
-      "integrity": "sha512-jdg5w9PCBYN6UQWV1630HDrXGfhld785d6XWGgGhYO+gMNB0R0gs8Si2lzvi7KYzHv7Ff/gOy+vAm63WVoXBvA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-4.1.1.tgz",
+      "integrity": "sha512-RG8mis311lCInldzorDSai6QfFavMqRUEzl/gY3KcEQzxaB3kBNQ86A6SawjSKBTrtcwFzYpdpddqUQuaE0KbA==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.23.7",
-        "@babel/types": "^7.23.6",
+        "@babel/core": "^7.23.9",
+        "@babel/types": "^7.23.9",
         "@microsoft/api-extractor": "^7.39.4",
         "@microsoft/tsdoc-config": "^0.16.2",
         "@rollup/plugin-alias": "^5.1.0",
@@ -4857,11 +4858,11 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-terser": "^0.4.4",
         "@sanity/browserslist-config": "^1.0.0",
-        "browserslist": "^4.22.2",
+        "browserslist": "^4.22.3",
         "cac": "^6.7.14",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
-        "esbuild": "^0.19.12",
+        "esbuild": "^0.20.0",
         "esbuild-register": "^3.5.0",
         "find-config": "^1.0.0",
         "get-latest-version": "^5.1.0",
@@ -4893,6 +4894,374 @@
       },
       "peerDependencies": {
         "typescript": "^4.7 || ^5"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz",
+      "integrity": "sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
+      "integrity": "sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
+      "integrity": "sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.0.tgz",
+      "integrity": "sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
+      "integrity": "sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz",
+      "integrity": "sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz",
+      "integrity": "sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz",
+      "integrity": "sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz",
+      "integrity": "sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz",
+      "integrity": "sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz",
+      "integrity": "sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz",
+      "integrity": "sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz",
+      "integrity": "sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz",
+      "integrity": "sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz",
+      "integrity": "sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz",
+      "integrity": "sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz",
+      "integrity": "sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz",
+      "integrity": "sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz",
+      "integrity": "sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz",
+      "integrity": "sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz",
+      "integrity": "sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz",
+      "integrity": "sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz",
+      "integrity": "sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sanity/pkg-utils/node_modules/ansi-styles": {
@@ -4943,6 +5312,44 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/@sanity/pkg-utils/node_modules/esbuild": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.0.tgz",
+      "integrity": "sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.0",
+        "@esbuild/android-arm": "0.20.0",
+        "@esbuild/android-arm64": "0.20.0",
+        "@esbuild/android-x64": "0.20.0",
+        "@esbuild/darwin-arm64": "0.20.0",
+        "@esbuild/darwin-x64": "0.20.0",
+        "@esbuild/freebsd-arm64": "0.20.0",
+        "@esbuild/freebsd-x64": "0.20.0",
+        "@esbuild/linux-arm": "0.20.0",
+        "@esbuild/linux-arm64": "0.20.0",
+        "@esbuild/linux-ia32": "0.20.0",
+        "@esbuild/linux-loong64": "0.20.0",
+        "@esbuild/linux-mips64el": "0.20.0",
+        "@esbuild/linux-ppc64": "0.20.0",
+        "@esbuild/linux-riscv64": "0.20.0",
+        "@esbuild/linux-s390x": "0.20.0",
+        "@esbuild/linux-x64": "0.20.0",
+        "@esbuild/netbsd-x64": "0.20.0",
+        "@esbuild/openbsd-x64": "0.20.0",
+        "@esbuild/sunos-x64": "0.20.0",
+        "@esbuild/win32-arm64": "0.20.0",
+        "@esbuild/win32-ia32": "0.20.0",
+        "@esbuild/win32-x64": "0.20.0"
+      }
     },
     "node_modules/@sanity/pkg-utils/node_modules/has-flag": {
       "version": "4.0.0",
@@ -5219,11 +5626,11 @@
       }
     },
     "node_modules/@sanity/webhook": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/webhook/-/webhook-4.0.1.tgz",
-      "integrity": "sha512-hswDXWD6Ru2qz0oMlEOathKspEyoc/jNFgAGvQVWQ4sbQDjVveMkLimQO+4FNWwi1AMYdcEmj+XmCzrPKIuvWA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/webhook/-/webhook-4.0.0.tgz",
+      "integrity": "sha512-IRjtj17tHSmxHWZvgRnLZbWj8J8G4jqOWOYC25eV4EcfVn1yZCs0x+km6+PSiJgOphSX6Nm1+X6UJOT+GnWIFw==",
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@sigstore/bundle": {
@@ -7097,9 +7504,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "dev": true,
       "funding": [
         {
@@ -7116,8 +7523,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
         "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
@@ -8365,9 +8772,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.646",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.646.tgz",
-      "integrity": "sha512-vThkQ0JuF45qT/20KbRgM56lV7IuGt7SjhawQ719PDHzhP84KAO1WJoaxgCoAffKHK47FmVKP1Fqizx7CwK1SA==",
+      "version": "1.4.648",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.648.tgz",
+      "integrity": "sha512-EmFMarXeqJp9cUKu/QEciEApn0S/xRcpZWuAm32U7NgoZCimjsilKXHRO9saeEW55eHZagIDg6XTUOv32w9pjg==",
       "dev": true
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -162,11 +162,12 @@
     "test:node-esm-cjs": "node test.mjs && node test.cjs",
     "type-check": "tsc --noEmit"
   },
-  "browserslist": [
-    "> 0.2% and supports es6-module and supports es6-module-dynamic-import and not dead and not IE 11",
-    "maintained node versions"
-  ],
+  "browserslist": "extends @sanity/browserslist-config",
   "prettier": {
+    "plugins": [
+      "prettier-plugin-packagejson",
+      "prettier-plugin-tailwindcss"
+    ],
     "bracketSpacing": false,
     "printWidth": 98,
     "semi": false,
@@ -175,17 +176,18 @@
   "dependencies": {
     "@sanity/client": "^6.12.1",
     "@sanity/preview-kit": "5.0.17",
-    "@sanity/webhook": "4.0.1",
+    "@sanity/webhook": "4.0.0",
     "groq": "^3.19"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^14.1.0",
     "@next/eslint-plugin-next": "14.1.0",
     "@rollup/plugin-terser": "^0.4.4",
+    "@sanity/browserslist-config": "^1.0.0",
     "@sanity/eslint-config-studio": "^3.0.1",
     "@sanity/image-url": "^1.0.2",
     "@sanity/overlays": "2.3.8",
-    "@sanity/pkg-utils": "^4.1.0",
+    "@sanity/pkg-utils": "^4.1.1",
     "@sanity/ui": "^2.0.1",
     "@sanity/vision": "3.26.1",
     "@types/react": "^18.2.48",


### PR DESCRIPTION
Relates to #942. In v4.0.1 of `@sanity/webhook` it started specifying node v20 as its recommended engine. [This is due to Node not shipping Web Crypto in v18.](https://github.com/sanity-io/webhook-toolkit/issues/44) Next.js gets around this by polyfilling these APIs so that they're available, both in the Node and Edge runtimes.
v4.0.1 is otherwise identical to v4.0.0 so the best course of action is to downgrade to 4.0.0 for now. By the time we make changes to `@sanity/webhook` we'll likely have Node v20 be the LTS.