### PR TITLE
feat: add `<VisualEditing />` component

### DIFF
--- a/app/PreviewProvider.tsx
+++ b/app/PreviewProvider.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import {use} from 'react'
 import {LiveQueryProvider} from 'src/preview'
+
+import {client} from './sanity.client'
 
 export default function PreviewProvider({
   children,
@@ -10,7 +11,6 @@ export default function PreviewProvider({
   children: React.ReactNode
   token: string
 }) {
-  const {client} = use(import('./sanity.client'))
   if (!token) throw new TypeError('Missing token')
   return (
     <LiveQueryProvider client={client} token={token} logger={console}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,10 @@
 import './globals.css'
 
-import dynamic from 'next/dynamic'
 import {draftMode} from 'next/headers'
+import {VisualEditing} from 'src'
 
 import ConditionalPreviewProvider from './ConditionalPreviewProvider'
 import StyledComponentsRegistry from './registry'
-
-const VisualEditing = dynamic(() => import('./VisualEditing'))
 
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (

--- a/app/studio/[[...tool]]/Studio.tsx
+++ b/app/studio/[[...tool]]/Studio.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import {use} from 'react'
+import config from 'sanity.config'
 import {NextStudio} from 'src/studio'
 
 export default function Studio() {
-  const {default: config} = use(import('sanity.config'))
   return (
     <NextStudio
       config={config}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@sanity/client": "^6.12.3",
         "@sanity/preview-kit": "5.0.19",
+        "@sanity/visual-editing": "1.0.1",
         "@sanity/webhook": "4.0.0",
         "groq": "^3.19"
       },
@@ -24,7 +25,6 @@
         "@sanity/pkg-utils": "^4.1.3",
         "@sanity/ui": "^2.0.1",
         "@sanity/vision": "3.27.1",
-        "@sanity/visual-editing": "1.0.1",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.18",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -5696,7 +5696,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@sanity/visual-editing/-/visual-editing-1.0.1.tgz",
       "integrity": "sha512-7BawhAozxkZskdpwJxXi19dztMNju27RPDzsBZQZV/HJnzAm7gdcpZJSkpGBpMbIY0+9HNGkqlajMAjXGiFE1w==",
-      "dev": true,
       "dependencies": {
         "@vercel/stega": "0.1.0",
         "react": "^18.2.0",
@@ -8468,8 +8467,7 @@
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==",
-      "dev": true
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -16809,7 +16807,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -16871,8 +16868,7 @@
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -18357,7 +18353,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -18384,7 +18379,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
-      "dev": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }

--- a/package.config.ts
+++ b/package.config.ts
@@ -1,7 +1,10 @@
 import terser from '@rollup/plugin-terser'
 import {defineConfig} from '@sanity/pkg-utils'
 
-const MODULE_PATHES_WHICH_USE_CLIENT_DIRECTIVE_SHOULD_BE_ADDED = ['NextStudioLoading.tsx']
+const MODULE_PATHS_WHICH_USE_CLIENT_DIRECTIVE_SHOULD_BE_ADDED = [
+  'NextStudioLoading.tsx',
+  'VisualEditing.tsx',
+]
 
 export default defineConfig({
   tsconfig: 'tsconfig.build.json',
@@ -32,7 +35,7 @@ export default defineConfig({
       preserveModulesRoot: 'src',
       banner: (chunkInfo) => {
         if (
-          MODULE_PATHES_WHICH_USE_CLIENT_DIRECTIVE_SHOULD_BE_ADDED.find((modulePath) =>
+          MODULE_PATHS_WHICH_USE_CLIENT_DIRECTIVE_SHOULD_BE_ADDED.find((modulePath) =>
             chunkInfo.facadeModuleId?.endsWith(modulePath),
           )
         ) {

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
   "dependencies": {
     "@sanity/client": "^6.12.3",
     "@sanity/preview-kit": "5.0.19",
+    "@sanity/visual-editing": "1.0.1",
     "@sanity/webhook": "4.0.0",
     "groq": "^3.19"
   },
@@ -189,7 +190,6 @@
     "@sanity/pkg-utils": "^4.1.3",
     "@sanity/ui": "^2.0.1",
     "@sanity/vision": "3.27.1",
-    "@sanity/visual-editing": "1.0.1",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './client'
+export {VisualEditing} from './visual-editing'
+export type {VisualEditingProps} from './visual-editing/VisualEditing'
 export {default as groq} from 'groq'

--- a/src/visual-editing/VisualEditing.tsx
+++ b/src/visual-editing/VisualEditing.tsx
@@ -1,10 +1,26 @@
 'use client'
 
-import {enableVisualEditing, HistoryAdapterNavigate} from '@sanity/visual-editing'
-import {usePathname, useRouter, useSearchParams} from 'next/navigation'
+import {
+  enableVisualEditing,
+  type HistoryAdapterNavigate,
+  type VisualEditingOptions,
+} from '@sanity/visual-editing'
+import {usePathname, useRouter, useSearchParams} from 'next/navigation.js'
 import {useEffect, useRef, useState} from 'react'
 
-export default function VisualEditing() {
+/**
+ * @public
+ */
+export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'> {
+  /**
+   * @deprecated The histoy adapter is already implemented
+   */
+  history?: never
+}
+
+export default function VisualEditing(props: VisualEditingProps): null {
+  const {zIndex} = props
+
   const router = useRouter()
   const routerRef = useRef(router)
   const [navigate, setNavigate] = useState<HistoryAdapterNavigate | undefined>()
@@ -14,10 +30,10 @@ export default function VisualEditing() {
   }, [router])
   useEffect(() => {
     const disable = enableVisualEditing({
+      zIndex,
       history: {
-        // eslint-disable-next-line no-shadow
-        subscribe: (navigate) => {
-          setNavigate(() => navigate)
+        subscribe: (_navigate) => {
+          setNavigate(() => _navigate)
           return () => setNavigate(undefined)
         },
         update: (update) => {
@@ -35,7 +51,7 @@ export default function VisualEditing() {
       },
     })
     return () => disable()
-  }, [])
+  }, [zIndex])
 
   const pathname = usePathname()
   const searchParams = useSearchParams()

--- a/src/visual-editing/index.tsx
+++ b/src/visual-editing/index.tsx
@@ -1,0 +1,16 @@
+import {lazy, Suspense} from 'react'
+
+import type {VisualEditingProps} from './VisualEditing'
+
+const VisualEditingComponent = lazy(() => import('./VisualEditing'))
+
+/**
+ * @public
+ */
+export function VisualEditing(props: VisualEditingProps): React.ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <VisualEditingComponent {...props} />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
Usage:
```tsx
import {draftMode} from 'next/headers'
import {VisualEditing} from 'next-sanity'

export default function RootLayout({children}: {children: React.ReactNode}) {
  return (
    <html lang="en">
      <head />
      <body>
        {children}
        {draftMode().isEnabled && <VisualEditing />}
      </body>
    </html>
  )
}
```