### PR TITLE
docs: fix time-based revalidation rsc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The official [Sanity.io][sanity] toolkit for Next.js apps.
   - [Using Perspectives](#using-perspectives)
   - [Live Preview](#live-preview)
   - [Using `draftMode()` to de/activate previews](#using-draftmode-to-deactivate-previews)
+    - [Using `cache` and `revalidation` at the same time](#using-cache-and-revalidation-at-the-same-time)
 - [Visual Editing with Content Source Maps](#visual-editing-with-content-source-maps)
 - [Embedded Sanity Studio](#embedded-sanity-studio)
   - [Configuring Sanity Studio on a route](#configuring-sanity-studio-on-a-route)
@@ -227,6 +228,7 @@ type HomePageProps = {
 
 export async function HomeLayout({children}) {
   const home = await client.fetch<HomePageProps>(`*[_id == "home"][0]{...,navItems[]->}`,
+    {},
     {next: {
       revalidate: 3600 // look for updates to revalidate cache every hour
     }}


### PR DESCRIPTION
Adds `params` parameter to fix the example of `Time-based revalidation` in Next.js

`client.fetch` function API looks like this:

```
  /**
   * Perform a GROQ-query against the configured dataset.
   *
   * @param query - GROQ-query to perform
   * @param params - Optional query parameters
   * @param options - Optional request options
   */
  fetch<R = Any, Q extends QueryWithoutParams | QueryParams = QueryParams>(
    query: string,
    params: Q extends QueryWithoutParams ? QueryWithoutParams : Q,
    options?: FilteredResponseQueryOptions,
  ): Promise<R>
```

Yet, in the current example `options` parameter is passed as a second argument to `client.fetch` function which is not correct

```
  const home = await client.fetch<HomePageProps>(`*[_id == "home"][0]{...,navItems[]->}`,
    {next: {
      revalidate: 3600 // look for updates to revalidate cache every hour
    }}
  })
```

This PR just adds an empty object as a `params` argument to make this example fully functional.

