### PR TITLE
feat(visual-editing): add `basePath` support

### DIFF
--- a/apps/mvp/app/sanity.client.ts
+++ b/apps/mvp/app/sanity.client.ts
@@ -9,7 +9,7 @@ export const client = createClient({
   resultSourceMap: 'withKeyArraySelector',
   stega: {
     enabled: true,
-    studioUrl: '/studio',
+    studioUrl: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH || ''}/studio`,
     // logger: console,
   },
 })

--- a/apps/mvp/next.config.mjs
+++ b/apps/mvp/next.config.mjs
@@ -6,6 +6,7 @@ function requireResolve(id) {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: process.env.NEXT_PUBLIC_TEST_BASE_PATH,
   experimental: {
     taint: true,
   },

--- a/apps/mvp/sanity.config.ts
+++ b/apps/mvp/sanity.config.ts
@@ -27,7 +27,9 @@ function createConfig(basePath: string, stable: boolean) {
   const presentationTool = stable ? stablePresentationTool : experimentalPresentationTool
   return defineConfig({
     name,
-    basePath: `${basePath}/${name}`,
+    basePath: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH || ''}${basePath}/${name}`,
+    // basePath: `${basePath}/${name}`,
+    // basePath: `${name}`,
 
     projectId,
     dataset,

--- a/apps/mvp/sanity.config.ts
+++ b/apps/mvp/sanity.config.ts
@@ -19,7 +19,7 @@ const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
 
 const previewMode = {
-  enable: '/api/draft',
+  enable: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH || ''}/api/draft`,
 } satisfies PreviewUrlResolverOptions['previewMode']
 
 function createConfig(basePath: string, stable: boolean) {
@@ -38,7 +38,7 @@ function createConfig(basePath: string, stable: boolean) {
       assist(),
       debugSecrets(),
       presentationTool({
-        previewUrl: {previewMode},
+        previewUrl: {preview: process.env.NEXT_PUBLIC_TEST_BASE_PATH || '/', previewMode},
       }),
       structureTool(),
       visionTool(),

--- a/packages/next-sanity/src/visual-editing/client-component/index.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/index.ts
@@ -19,13 +19,17 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
    */
   history?: never
   /**
+   * If next.config.ts is configured with a basePath we try to configure it automatically,
+   * you can disable this by setting basePath to ''.
+   * @example basePath="/my-custom-base-path"
    * @alpha experimental and may change without notice
+   * @defaultValue process.env.__NEXT_ROUTER_BASEPATH || ''
    */
-  basePath: string
+  basePath?: string
 }
 
 export default function VisualEditing(props: VisualEditingProps): null {
-  const {refresh, zIndex, basePath} = props
+  const {refresh, zIndex, basePath = ''} = props
 
   const router = useRouter()
   const routerRef = useRef(router)

--- a/packages/next-sanity/src/visual-editing/client-component/utils.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/utils.ts
@@ -65,6 +65,11 @@ export function addPathPrefix(path: string, prefix?: string): string {
  * @param prefix The prefix to be removed.
  */
 export function removePathPrefix(path: string, prefix: string): string {
+  // If the path is exactly '/' then return just the prefix
+  if (path === '/' && prefix) {
+    return prefix
+  }
+
   // If the path doesn't start with the prefix we can return it as is. This
   // protects us from situations where the prefix is a substring of the path
   // prefix such as:

--- a/packages/next-sanity/src/visual-editing/client-component/utils.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/utils.ts
@@ -50,6 +50,10 @@ export function addPathPrefix(path: string, prefix?: string): string {
   if (!path.startsWith('/') || !prefix) {
     return path
   }
+  // If the path is exactly '/' then return just the prefix
+  if (path === '/' && prefix) {
+    return prefix
+  }
 
   const {pathname, query, hash} = parsePath(path)
   return `${prefix}${pathname}${query}${hash}`
@@ -65,11 +69,6 @@ export function addPathPrefix(path: string, prefix?: string): string {
  * @param prefix The prefix to be removed.
  */
 export function removePathPrefix(path: string, prefix: string): string {
-  // If the path is exactly '/' then return just the prefix
-  if (path === '/' && prefix) {
-    return prefix
-  }
-
   // If the path doesn't start with the prefix we can return it as is. This
   // protects us from situations where the prefix is a substring of the path
   // prefix such as:

--- a/packages/next-sanity/src/visual-editing/client-component/utils.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/utils.ts
@@ -1,0 +1,95 @@
+/**
+ * From: https://github.com/vercel/next.js/blob/5469e6427b54ab7e9876d4c85b47f9c3afdc5c1f/packages/next/src/shared/lib/router/utils/path-has-prefix.ts#L10-L17
+ * Checks if a given path starts with a given prefix. It ensures it matches
+ * exactly without containing extra chars. e.g. prefix /docs should replace
+ * for /docs, /docs/, /docs/a but not /docsss
+ * @param path The path to check.
+ * @param prefix The prefix to check against.
+ */
+function pathHasPrefix(path: string, prefix: string): boolean {
+  if (typeof path !== 'string') {
+    return false
+  }
+
+  const {pathname} = parsePath(path)
+  return pathname === prefix || pathname.startsWith(`${prefix}/`)
+}
+
+/**
+ * From: https://github.com/vercel/next.js/blob/5469e6427b54ab7e9876d4c85b47f9c3afdc5c1f/packages/next/src/shared/lib/router/utils/parse-path.ts#L6-L22
+ * Given a path this function will find the pathname, query and hash and return
+ * them. This is useful to parse full paths on the client side.
+ * @param path A path to parse e.g. /foo/bar?id=1#hash
+ */
+function parsePath(path: string): {
+  pathname: string
+  query: string
+  hash: string
+} {
+  const hashIndex = path.indexOf('#')
+  const queryIndex = path.indexOf('?')
+  const hasQuery = queryIndex > -1 && (hashIndex < 0 || queryIndex < hashIndex)
+
+  if (hasQuery || hashIndex > -1) {
+    return {
+      pathname: path.substring(0, hasQuery ? queryIndex : hashIndex),
+      query: hasQuery ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined) : '',
+      hash: hashIndex > -1 ? path.slice(hashIndex) : '',
+    }
+  }
+
+  return {pathname: path, query: '', hash: ''}
+}
+
+/**
+ * From: https://github.com/vercel/next.js/blob/5469e6427b54ab7e9876d4c85b47f9c3afdc5c1f/packages/next/src/shared/lib/router/utils/add-path-prefix.ts#L3C1-L14C2
+ * Adds the provided prefix to the given path. It first ensures that the path
+ * is indeed starting with a slash.
+ */
+export function addPathPrefix(path: string, prefix?: string): string {
+  if (!path.startsWith('/') || !prefix) {
+    return path
+  }
+
+  const {pathname, query, hash} = parsePath(path)
+  return `${prefix}${pathname}${query}${hash}`
+}
+
+/**
+ * From: https://github.com/vercel/next.js/blob/5469e6427b54ab7e9876d4c85b47f9c3afdc5c1f/packages/next/src/shared/lib/router/utils/remove-path-prefix.ts#L3-L39
+ * Given a path and a prefix it will remove the prefix when it exists in the
+ * given path. It ensures it matches exactly without containing extra chars
+ * and if the prefix is not there it will be noop.
+ *
+ * @param path The path to remove the prefix from.
+ * @param prefix The prefix to be removed.
+ */
+export function removePathPrefix(path: string, prefix: string): string {
+  // If the path doesn't start with the prefix we can return it as is. This
+  // protects us from situations where the prefix is a substring of the path
+  // prefix such as:
+  //
+  // For prefix: /blog
+  //
+  //   /blog -> true
+  //   /blog/ -> true
+  //   /blog/1 -> true
+  //   /blogging -> false
+  //   /blogging/ -> false
+  //   /blogging/1 -> false
+  if (!pathHasPrefix(path, prefix)) {
+    return path
+  }
+
+  // Remove the prefix from the path via slicing.
+  const withoutPrefix = path.slice(prefix.length)
+
+  // If the path without the prefix starts with a `/` we can return it as is.
+  if (withoutPrefix.startsWith('/')) {
+    return withoutPrefix
+  }
+
+  // If the path without the prefix doesn't start with a `/` we need to add it
+  // back to the path to make sure it's a valid path.
+  return `/${withoutPrefix}`
+}

--- a/packages/next-sanity/src/visual-editing/index.tsx
+++ b/packages/next-sanity/src/visual-editing/index.tsx
@@ -12,15 +12,17 @@ export function VisualEditing(props: VisualEditingProps): React.ReactElement {
   // or disable the auto mode by setting basePath to false
 
   let autoBasePath: string | undefined
-  try {
-    autoBasePath = process.env['__NEXT_ROUTER_BASEPATH']
-    if (autoBasePath) {
-      console.warn(
-        `Detected next basePath as ${JSON.stringify(autoBasePath)} by reading "process.env.__NEXT_ROUTER_BASEPATH". If this is incorrect then you can set it manually with the basePath prop on the <VisualEditing /> component.`,
-      )
+  if (typeof props.basePath !== 'string') {
+    try {
+      autoBasePath = process.env['__NEXT_ROUTER_BASEPATH']
+      if (autoBasePath) {
+        console.warn(
+          `Detected next basePath as ${JSON.stringify(autoBasePath)} by reading "process.env.__NEXT_ROUTER_BASEPATH". If this is incorrect then you can set it manually with the basePath prop on the <VisualEditing /> component.`,
+        )
+      }
+    } catch (err) {
+      console.error('Failed detecting basePath', err)
     }
-  } catch (err) {
-    console.error('Failed detecting basePath', err)
   }
   return (
     <Suspense fallback={null}>

--- a/packages/next-sanity/src/visual-editing/index.tsx
+++ b/packages/next-sanity/src/visual-editing/index.tsx
@@ -8,15 +8,13 @@ const VisualEditingComponent = lazy(() => import('next-sanity/visual-editing/cli
  * @public
  */
 export function VisualEditing(props: VisualEditingProps): React.ReactElement {
-  // detected basePath, its value, you can change it by setting the basePath prop on VisualEditing
-  // or disable the auto mode by setting basePath to false
-
   let autoBasePath: string | undefined
   if (typeof props.basePath !== 'string') {
     try {
       autoBasePath = process.env['__NEXT_ROUTER_BASEPATH']
       if (autoBasePath) {
-        console.warn(
+        // eslint-disable-next-line no-console
+        console.log(
           `Detected next basePath as ${JSON.stringify(autoBasePath)} by reading "process.env.__NEXT_ROUTER_BASEPATH". If this is incorrect then you can set it manually with the basePath prop on the <VisualEditing /> component.`,
         )
       }

--- a/packages/next-sanity/src/visual-editing/index.tsx
+++ b/packages/next-sanity/src/visual-editing/index.tsx
@@ -7,24 +7,18 @@ const VisualEditingComponent = lazy(() => import('next-sanity/visual-editing/cli
 /**
  * @public
  */
-export function VisualEditing(
-  props: VisualEditingProps & {
-    /**
-     * If next.config.ts is configured with a basePath we try to configure it automatically,
-     * you can disable this by setting basePath to ''.
-     * @example basePath="/my-custom-base-path"
-     * @alpha experimental and may change without notice
-     * @defaultValue process.env.__NEXT_ROUTER_BASEPATH || ''
-     */
-    basePath?: string
-  },
-): React.ReactElement {
+export function VisualEditing(props: VisualEditingProps): React.ReactElement {
   // detected basePath, its value, you can change it by setting the basePath prop on VisualEditing
   // or disable the auto mode by setting basePath to false
 
-  let autoBasePath = ''
+  let autoBasePath: string | undefined
   try {
-    autoBasePath = (process.env['__NEXT_ROUTER_BASEPATH'] as string) || ''
+    autoBasePath = process.env['__NEXT_ROUTER_BASEPATH']
+    if (autoBasePath) {
+      console.warn(
+        `Detected next basePath as ${JSON.stringify(autoBasePath)} by reading "process.env.__NEXT_ROUTER_BASEPATH". If this is incorrect then you can set it manually with the basePath prop on the <VisualEditing /> component.`,
+      )
+    }
   } catch (err) {
     console.error('Failed detecting basePath', err)
   }

--- a/packages/next-sanity/src/visual-editing/index.tsx
+++ b/packages/next-sanity/src/visual-editing/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation */
 import type {VisualEditingProps} from 'next-sanity/visual-editing/client-component'
 import {lazy, Suspense} from 'react'
 
@@ -6,10 +7,30 @@ const VisualEditingComponent = lazy(() => import('next-sanity/visual-editing/cli
 /**
  * @public
  */
-export function VisualEditing(props: VisualEditingProps): React.ReactElement {
+export function VisualEditing(
+  props: VisualEditingProps & {
+    /**
+     * If next.config.ts is configured with a basePath we try to configure it automatically,
+     * you can disable this by setting basePath to ''.
+     * @example basePath="/my-custom-base-path"
+     * @alpha experimental and may change without notice
+     * @defaultValue process.env.__NEXT_ROUTER_BASEPATH || ''
+     */
+    basePath?: string
+  },
+): React.ReactElement {
+  // detected basePath, its value, you can change it by setting the basePath prop on VisualEditing
+  // or disable the auto mode by setting basePath to false
+
+  let autoBasePath = ''
+  try {
+    autoBasePath = (process.env['__NEXT_ROUTER_BASEPATH'] as string) || ''
+  } catch (err) {
+    console.error('Failed detecting basePath', err)
+  }
   return (
     <Suspense fallback={null}>
-      <VisualEditingComponent {...props} />
+      <VisualEditingComponent {...props} basePath={props.basePath ?? autoBasePath} />
     </Suspense>
   )
 }

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
   "pipeline": {
     "build": {
       "dotEnv": [".env", ".env.local"],
-      "env": ["NEXT_PUBLIC_SANITY_*", "NEXT_PUBLIC_VERCEL_ENV"],
+      "env": ["NEXT_PUBLIC_SANITY_*", "NEXT_PUBLIC_VERCEL_ENV", "NEXT_PUBLIC_TEST_BASE_PATH"],
       "outputs": [".next/**", "!.next/cache/**", "out/**"],
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
Adds `basePath` support to `<VisualEditing />` to integrate with https://nextjs.org/docs/app/api-reference/next-config-js/basePath

The default value is detected by reading the same env variable that next.js reads internally. Since it's an internal env variable it'll console.warn telling you to add the prop manually to ensure it'll keep working should next.js change in the future:
```bash
Detected next basePath as "/e2e" by reading "process.env.__NEXT_ROUTER_BASEPATH". If this is incorrect then you can set it manually with the basePath prop on the <VisualEditing /> component.
```

When using `basePath` with Presentation Tool it's important that the prefix must be added on these touch points, assuming `next.config.ts` sets `basePath: '/docs'` and that the studio is mounted on `./app/studio/[[...tool]]/page.tsx`
```ts
// sanity.config.ts

export default {
  basePath: '/docs/studio',
  plugins: [
    presentationTool({
      previewUrl: {
        preview: '/docs',
        previewMode: { enable: '/docs/api/draft' }
      },
      resolve, // all urls returned here must be prefixed with `/docs`
      locate, // all urls returned here must be prefixed with `/docs`
    })
  ]
}
```