### PR TITLE
Set fit param to max on the image loader

### DIFF
--- a/packages/next-sanity/src/image/imageLoader.ts
+++ b/packages/next-sanity/src/image/imageLoader.ts
@@ -6,7 +6,8 @@ import type {ImageLoader} from 'next/image'
 export const imageLoader = (({src, width, quality}) => {
   const url = new URL(src)
   url.searchParams.set('auto', 'format')
-  url.searchParams.set('fit', url.searchParams.get('fit') || 'max')
+  url.searchParams.set('fit', url.searchParams.get('fit') || url.searchParams.has('h') ? 
+ 'min' : 'max')
   if (url.searchParams.has('h') && url.searchParams.has('w')) {
     const originalHeight = parseInt(url.searchParams.get('h')!, 10)
     const originalWidth = parseInt(url.searchParams.get('w')!, 10)

--- a/packages/next-sanity/src/image/imageLoader.ts
+++ b/packages/next-sanity/src/image/imageLoader.ts
@@ -6,7 +6,7 @@ import type {ImageLoader} from 'next/image'
 export const imageLoader = (({src, width, quality}) => {
   const url = new URL(src)
   url.searchParams.set('auto', 'format')
-  url.searchParams.set('fit', url.searchParams.get('fit') || 'min')
+  url.searchParams.set('fit', url.searchParams.get('fit') || 'max')
   if (url.searchParams.has('h') && url.searchParams.has('w')) {
     const originalHeight = parseInt(url.searchParams.get('h')!, 10)
     const originalWidth = parseInt(url.searchParams.get('w')!, 10)


### PR DESCRIPTION
The default value for the fit param should be set to max to support the vertical images out of the box.