### PR TITLE
feat(visual-editing): add `trailingSlash ` support

### DIFF
--- a/apps/mvp/next.config.mjs
+++ b/apps/mvp/next.config.mjs
@@ -7,6 +7,7 @@ function requireResolve(id) {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   basePath: process.env.NEXT_PUBLIC_TEST_BASE_PATH,
+  trailingSlash: true,
   experimental: {
     taint: true,
     reactCompiler: true,

--- a/apps/mvp/sanity.config.ts
+++ b/apps/mvp/sanity.config.ts
@@ -19,7 +19,7 @@ const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
 
 const previewMode = {
-  enable: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH || ''}/api/draft`,
+  enable: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH || ''}/api/draft/`,
 } satisfies PreviewUrlResolverOptions['previewMode']
 
 function createConfig(basePath: string, stable: boolean) {
@@ -38,7 +38,7 @@ function createConfig(basePath: string, stable: boolean) {
       assist(),
       debugSecrets(),
       presentationTool({
-        previewUrl: {preview: process.env.NEXT_PUBLIC_TEST_BASE_PATH || '/', previewMode},
+        previewUrl: {preview: `${process.env.NEXT_PUBLIC_TEST_BASE_PATH}/` || '/', previewMode},
       }),
       structureTool(),
       visionTool(),

--- a/packages/next-sanity/src/visual-editing/client-component/index.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/index.ts
@@ -8,7 +8,7 @@ import {usePathname, useRouter, useSearchParams} from 'next/navigation.js'
 import {revalidateRootLayout} from 'next-sanity/visual-editing/server-actions'
 import {useEffect, useRef, useState} from 'react'
 
-import {addPathPrefix, removePathPrefix} from './utils'
+import {addPathPrefix, normalizePathTrailingSlash, removePathPrefix} from './utils'
 
 /**
  * @public
@@ -26,10 +26,18 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
    * @defaultValue process.env.__NEXT_ROUTER_BASEPATH || ''
    */
   basePath?: string
+  /**
+   * If next.config.ts is configured with a `trailingSlash` we try to detect it automatically,
+   * it can be controlled manually by passing a boolean.
+   * @example trailingSlash={true}
+   * @alpha experimental and may change without notice
+   * @defaultValue Boolean(process.env.__NEXT_TRAILING_SLASH)
+   */
+  trailingSlash?: boolean
 }
 
 export default function VisualEditing(props: VisualEditingProps): null {
-  const {refresh, zIndex, basePath = ''} = props
+  const {refresh, zIndex, basePath = '', trailingSlash = false} = props
 
   const router = useRouter()
   const routerRef = useRef(router)
@@ -114,13 +122,13 @@ export default function VisualEditing(props: VisualEditingProps): null {
     if (navigate) {
       navigate({
         type: 'push',
-        url: addPathPrefix(
-          `${pathname}${searchParams?.size ? `?${searchParams}` : ''}`,
-          basePath,
+        url: normalizePathTrailingSlash(
+          addPathPrefix(`${pathname}${searchParams?.size ? `?${searchParams}` : ''}`, basePath),
+          trailingSlash,
         ),
       })
     }
-  }, [basePath, navigate, pathname, searchParams])
+  }, [basePath, navigate, pathname, searchParams, trailingSlash])
 
   return null
 }

--- a/packages/next-sanity/src/visual-editing/client-component/utils.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/utils.ts
@@ -97,3 +97,32 @@ export function removePathPrefix(path: string, prefix: string): string {
   // back to the path to make sure it's a valid path.
   return `/${withoutPrefix}`
 }
+
+/**
+ * From: https://github.com/vercel/next.js/blob/dfe7fc03e2268e7cb765dce6a89e02c831c922d5/packages/next/src/client/normalize-trailing-slash.ts#L16
+ * Normalizes the trailing slash of a path according to the `trailingSlash` option
+ * in `next.config.js`.
+ */
+export const normalizePathTrailingSlash = (path: string, trailingSlash: boolean): string => {
+  const {pathname, query, hash} = parsePath(path)
+  if (trailingSlash) {
+    if (pathname.endsWith('/')) {
+      return `${pathname}${query}${hash}`
+    }
+    return `${pathname}/${query}${hash}`
+  }
+
+  return `${removeTrailingSlash(pathname)}${query}${hash}`
+}
+
+/**
+ * From: https://github.com/vercel/next.js/blob/dfe7fc03e2268e7cb765dce6a89e02c831c922d5/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts#L8
+ * Removes the trailing slash for a given route or page path. Preserves the
+ * root page. Examples:
+ *   - `/foo/bar/` -> `/foo/bar`
+ *   - `/foo/bar` -> `/foo/bar`
+ *   - `/` -> `/`
+ */
+function removeTrailingSlash(route: string) {
+  return route.replace(/\/$/, '') || '/'
+}

--- a/packages/next-sanity/src/visual-editing/index.tsx
+++ b/packages/next-sanity/src/visual-editing/index.tsx
@@ -22,9 +22,27 @@ export function VisualEditing(props: VisualEditingProps): React.ReactElement {
       console.error('Failed detecting basePath', err)
     }
   }
+  let autoTrailingSlash: boolean | undefined
+  if (typeof props.trailingSlash !== 'boolean') {
+    try {
+      autoTrailingSlash = Boolean(process.env['__NEXT_TRAILING_SLASH'])
+      if (autoTrailingSlash) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `Detected next trailingSlash as ${JSON.stringify(autoTrailingSlash)} by reading "process.env.__NEXT_TRAILING_SLASH". If this is incorrect then you can set it manually with the trailingSlash prop on the <VisualEditing /> component.`,
+        )
+      }
+    } catch (err) {
+      console.error('Failed detecting trailingSlash', err)
+    }
+  }
   return (
     <Suspense fallback={null}>
-      <VisualEditingComponent {...props} basePath={props.basePath ?? autoBasePath} />
+      <VisualEditingComponent
+        {...props}
+        basePath={props.basePath ?? autoBasePath}
+        trailingSlash={props.trailingSlash ?? autoTrailingSlash}
+      />
     </Suspense>
   )
 }


### PR DESCRIPTION
Like #1510 this PR adds `trailingSlash` support to `<VisualEditing />` to integrate with https://nextjs.org/docs/pages/api-reference/next-config-js/trailingSlash

The default value is detected by reading the same env variable that next.js reads internally. Since it's an internal env variable it'll console.warn telling you to add the prop manually to ensure it'll keep working should next.js change in the future:
```bash
Detected next trailingSlash as true by reading "process.env.__NEXT_TRAILING_SLASH". If this is incorrect then you can set it manually with the trailingSlash prop on the <VisualEditing /> component.
```

When using `trailingSlash` with Presentation Tool it's important that the suffix must be added on these touch points, assuming `next.config.ts` sets `basePath: '/docs'` and that the studio is mounted on `./app/studio/[[...tool]]/page.tsx`
```ts
// sanity.config.ts

export default {
  basePath: '/docs/studio',
  plugins: [
    presentationTool({
      previewUrl: {
        preview: '/docs/',
        previewMode: { enable: '/docs/api/draft/' }
      },
      resolve, // all urls returned here must be prefixed with `/docs` and have a trailing `/` suffix
      locate, // all urls returned here must be prefixed with `/docs` and have a trailing `/` suffix
    })
  ]
}
```

To test this locally run `NEXT_PUBLIC_TEST_BASE_PATH="/docs" pnpm dev` and open `http://localhost/docs/studio` and everything should work (no redirect loop)