### PR TITLE
fix: pass additional visual editing props

### DIFF
--- a/packages/next-sanity/src/visual-editing/client-component/index.ts
+++ b/packages/next-sanity/src/visual-editing/client-component/index.ts
@@ -37,7 +37,7 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
 }
 
 export default function VisualEditing(props: VisualEditingProps): null {
-  const {refresh, zIndex, basePath = '', trailingSlash = false} = props
+  const {refresh, zIndex, basePath = '', trailingSlash = false, ...rest} = props
 
   const router = useRouter()
   const routerRef = useRef(router)
@@ -48,6 +48,7 @@ export default function VisualEditing(props: VisualEditingProps): null {
   }, [router])
   useEffect(() => {
     const disable = enableVisualEditing({
+      ...rest,
       zIndex,
       refresh: refresh
         ? refresh
@@ -114,7 +115,7 @@ export default function VisualEditing(props: VisualEditingProps): null {
     }
 
     return () => disable()
-  }, [basePath, refresh, zIndex])
+  }, [basePath, refresh, rest, zIndex])
 
   const pathname = usePathname()
   const searchParams = useSearchParams()


### PR DESCRIPTION
The props accepted by this package's `VisualEditing` component (`VisualEditingProps`) extend the options accepted by the `enableVisualEditing` function exported from `@sanity/visual-editing` (`VisualEditingOptions`) .

Any additional options we add to the underlying visual editing function currently won't be passed by `next-sanity`'s visual editing component. This PR just ensures any additional props are passed, so we can iterate on `@sanity/visual-editing` without having to manually propagate the same changes in this package.