### PR TITLE
fix: ensure draft mode cookies are set on safari

### DIFF
--- a/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
+++ b/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
@@ -59,6 +59,8 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
         draftModeStore.enable()
       }
 
+      const dev = process.env.NODE_ENV !== 'production'
+
       // Override cookie header for draft mode for usage in live-preview
       // https://github.com/vercel/next.js/issues/49927
       const cookieStore = await cookies()
@@ -68,8 +70,8 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
         value: cookie?.value,
         httpOnly: true,
         path: '/',
-        secure: true,
-        sameSite: 'none',
+        secure: !dev,
+        sameSite: dev ? 'lax' : 'none',
       })
 
       if (studioPreviewPerspective) {
@@ -78,8 +80,8 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
           value: studioPreviewPerspective,
           httpOnly: true,
           path: '/',
-          secure: true,
-          sameSite: 'none',
+          secure: !dev,
+          sameSite: dev ? 'lax' : 'none',
         })
       }
 


### PR DESCRIPTION
Small change to follow the same conventions for setting the preview/draft cookie as with other frameworks we support.

Safari seems to have issues with setting secure cookies over http within an iframe, or at least some subset of that combination.

Seems to do the trick on the Vercel deployment over https too.