### PR TITLE
imageLoader: do not overwrite existing fit param

### DIFF
--- a/packages/next-sanity/src/image/imageLoader.ts
+++ b/packages/next-sanity/src/image/imageLoader.ts
@@ -6,10 +6,9 @@ import type {ImageLoader} from 'next/image'
 export const imageLoader = (({src, width, quality}) => {
   const url = new URL(src)
   url.searchParams.set('auto', 'format')
-  url.searchParams.set(
-    'fit',
-    url.searchParams.get('fit') || url.searchParams.has('h') ? 'min' : 'max',
-  )
+  if (!url.searchParams.has('fit')) {
+    url.searchParams.set('fit', url.searchParams.has('h') ? 'min' : 'max')
+  }
   if (url.searchParams.has('h') && url.searchParams.has('w')) {
     const originalHeight = parseInt(url.searchParams.get('h')!, 10)
     const originalWidth = parseInt(url.searchParams.get('w')!, 10)

--- a/packages/next-sanity/test/imageLoader.test.ts
+++ b/packages/next-sanity/test/imageLoader.test.ts
@@ -1,0 +1,99 @@
+import {expect, test} from 'vitest'
+
+import {imageLoader} from '../src/image/imageLoader'
+
+test('adds basic width and format parameters', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?auto=format&fit=max&w=800',
+  )
+})
+
+test('preserves existing URL parameters', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg?blur=50',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?blur=50&auto=format&fit=max&w=800',
+  )
+})
+
+test('adds quality parameter when specified', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg',
+    width: 800,
+    quality: 75,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?auto=format&fit=max&w=800&q=75',
+  )
+})
+
+test('uses min fit when height parameter exists', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg?h=600',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?h=600&auto=format&fit=min&w=800',
+  )
+})
+
+test('calculates proportional height when both width and height exist', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg?w=1000&h=500',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?w=800&h=400&auto=format&fit=min',
+  )
+})
+
+test('respects existing fit parameter', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg?fit=crop',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?fit=crop&auto=format&w=800',
+  )
+})
+
+test('handles URLs with hash fragments', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg#fragment',
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?auto=format&fit=max&w=800#fragment',
+  )
+})
+
+test('handles complex URLs with multiple parameters', () => {
+  const result = imageLoader({
+    src: 'https://cdn.sanity.io/images/project/dataset/image.jpg?blur=50&sat=-100&w=1000&h=500',
+    width: 800,
+    quality: 90,
+  })
+
+  expect(result).toBe(
+    'https://cdn.sanity.io/images/project/dataset/image.jpg?blur=50&sat=-100&w=800&h=400&auto=format&fit=min&q=90',
+  )
+})


### PR DESCRIPTION
Noticed that the `imageLoader` fn overrides the `fit` param, even tho the code looks like it should only override it when not set. I had some issues with the `hotspot` not being set correctly, so I fixed this and copied the loader to my codebase. Perhaps someone else runs into the same issue. Also, added tests for `imageLoader`. 