### PR TITLE
fix(docs): replace `previewDrafts` with `drafts`

### DIFF
--- a/packages/next-sanity/PREVIEW-app-router.md
+++ b/packages/next-sanity/PREVIEW-app-router.md
@@ -48,7 +48,7 @@ export async function sanityFetch<QueryResponse>({
     ...(isDraftMode &&
       ({
         token: token,
-        perspective: 'previewDrafts',
+        perspective: 'drafts',
       } satisfies QueryOptions)),
     next: {
       revalidate: isDraftMode ? 0 : false,

--- a/packages/next-sanity/PREVIEW-pages-router.md
+++ b/packages/next-sanity/PREVIEW-pages-router.md
@@ -42,7 +42,7 @@ export async function sanityFetch<QueryResponse>({
 
   return client.fetch<QueryResponse>(query, params, {
     token,
-    perspective: draftMode ? 'previewDrafts' : 'published',
+    perspective: draftMode ? 'drafts' : 'published',
   })
 }
 ```

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -737,7 +737,7 @@ export async function generateStaticParams() {
 
 ### 4. Integrating with Next.js Draft Mode and Vercel Toolbar's Edit Mode
 
-To support previewing draft content when Draft Mode is enabled, the `serverToken` passed to `defineLive` should be assigned the Viewer role, which has the ability to fetch content using the `previewDrafts` perspective.
+To support previewing draft content when Draft Mode is enabled, the `serverToken` passed to `defineLive` should be assigned the Viewer role, which has the ability to fetch content using the `drafts` perspective.
 
 Click the Draft Mode button in the Vercel toolbar to enable draft content:
 


### PR DESCRIPTION
Since https://github.com/sanity-io/client/pull/1007 the client warns when using `perspective: 'previewDrafts'`. This PR refactors to the new `perspective: 'drafts'` approach.