### PR TITLE
feat: add visual editing overlay plugins

### DIFF
--- a/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
+++ b/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
@@ -38,7 +38,7 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
 }
 
 export default function VisualEditing(props: VisualEditingProps): React.JSX.Element | null {
-  const {basePath = '', components, refresh, trailingSlash = false, zIndex} = props
+  const {basePath = '', plugins, components, refresh, trailingSlash = false, zIndex} = props
 
   const router = useRouter()
   const routerRef = useRef(router)
@@ -132,6 +132,7 @@ export default function VisualEditing(props: VisualEditingProps): React.JSX.Elem
 
   return (
     <VisualEditingComponent
+      plugins={plugins}
       components={components}
       history={history}
       portal


### PR DESCRIPTION
Following the introduction of the new [`plugins` API for visual editing overlays](https://github.com/sanity-io/visual-editing/releases/tag/visual-editing-v2.14.0), we need to add support for the new `plugins` prop on the `VisualEditing` client component.