### PR TITLE
fix!: drop next v14 and react 18

### DIFF
--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -153,9 +153,9 @@
   "peerDependencies": {
     "@sanity/client": "catalog:",
     "@sanity/ui": "^2.16.7",
-    "next": "^14.2 || ^15.0.0-0",
-    "react": "^18.3 || ^19.0.0-0",
-    "react-dom": "^18.3 || ^19.0.0-0",
+    "next": "^15.1",
+    "react": "^19",
+    "react-dom": "^19",
     "sanity": "catalog:",
     "styled-components": "^6.1"
   },


### PR DESCRIPTION
[Since next v15.1 react 19 has been stable](https://nextjs.org/blog/next-15-1).