### PR TITLE
chore: release v11

### DIFF
--- a/apps/mvp/.gitignore
+++ b/apps/mvp/.gitignore
@@ -1,3 +1,4 @@
 .vercel
 .env*.local
 public/studio/static
+public/analyze

--- a/apps/mvp/next-env.d.ts
+++ b/apps/mvp/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/mvp/package.json
+++ b/apps/mvp/package.json
@@ -7,7 +7,8 @@
     "#groqd": "./groqd-client.ts"
   },
   "scripts": {
-    "build": "next build --profile && sanity manifest extract --path public/studio/static",
+    "build": "next build --profile && sanity manifest extract --path public/studio/static && pnpm copy-analyze",
+    "copy-analyze": "cp -r .next/analyze public/ || true",
     "dev": "next dev --turbo",
     "start": "next start",
     "type-check": "tsc --noEmit",

--- a/apps/mvp/tsconfig.json
+++ b/apps/mvp/tsconfig.json
@@ -9,7 +9,8 @@
     "module": "preserve",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "jsx": "react-jsx"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/static/.gitignore
+++ b/apps/static/.gitignore
@@ -1,0 +1,1 @@
+public/analyze

--- a/apps/static/app/page.tsx
+++ b/apps/static/app/page.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-html-link-for-pages */
-import {unstable__adapter, unstable__environment} from '@sanity/client'
+import {unstable__adapter, unstable__environment} from 'next-sanity'
 import Link from 'next/link'
 
 import PostsLayout, {type PostsLayoutProps, query} from '@/app/PostsLayout'

--- a/apps/static/app/sanity.client.ts
+++ b/apps/static/app/sanity.client.ts
@@ -1,4 +1,4 @@
-import {createClient} from '@sanity/client'
+import {createClient} from 'next-sanity'
 
 export const client = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
@@ -14,4 +14,4 @@ export const client = createClient({
   },
 })
 
-export type {QueryOptions, QueryParams} from '@sanity/client'
+export type {QueryOptions, QueryParams} from 'next-sanity'

--- a/apps/static/app/sanity.fetch.ts
+++ b/apps/static/app/sanity.fetch.ts
@@ -1,6 +1,4 @@
-import type {QueryParams} from '@sanity/client'
-
-import {client} from './sanity.client'
+import {client, type QueryParams} from './sanity.client'
 
 // eslint-disable-next-line no-process-env
 export const token = process.env.SANITY_API_READ_TOKEN!

--- a/apps/static/next-env.d.ts
+++ b/apps/static/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/static/next.config.ts
+++ b/apps/static/next.config.ts
@@ -1,7 +1,8 @@
+import type {NextConfig} from 'next'
+
 import withBundleAnalyzer from '@next/bundle-analyzer'
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
   output: 'export',
   logging: {
     fetches: {

--- a/apps/static/package.json
+++ b/apps/static/package.json
@@ -7,7 +7,8 @@
     "#groqd": "./groqd-client.ts"
   },
   "scripts": {
-    "build": "next build",
+    "build": "next build && pnpm copy-analyze",
+    "copy-analyze": "cp -r .next/analyze public/ || true",
     "dev": "next -p 3001 --turbo",
     "start": "pnpx serve@latest out -p 3001",
     "type-check": "tsc --noEmit",

--- a/apps/static/tsconfig.json
+++ b/apps/static/tsconfig.json
@@ -9,7 +9,8 @@
     "module": "preserve",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "jsx": "react-jsx"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -1153,8 +1153,9 @@ function StudioPage() {
 ## Migration guides
 
 > [!IMPORTANT]
-> You're looking at the README for v10, the README for [v9 is available here](https://github.com/sanity-io/next-sanity/tree/v9?tab=readme-ov-file#next-sanity) as well as an [migration guide][migrate-v9-to-v10].
+> You're looking at the README for v11, the README for [v10 is available here](https://github.com/sanity-io/next-sanity/tree/v10?tab=readme-ov-file#next-sanity) as well as an [migration guide][migrate-v10-to-v11].
 
+- [From `v10` to `v11`][migrate-v10-to-v11]
 - [From `v9` to `v10`][migrate-v9-to-v10]
 - [From `v8` to `v9`][migrate-v8-to-v9]
 - [From `v7` to `v8`][migrate-v7-to-v8]
@@ -1184,6 +1185,7 @@ MIT-licensed. See [LICENSE][LICENSE].
 [migrate-v7-to-v8]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v7-to-v8.md
 [migrate-v8-to-v9]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v8-to-v9.md
 [migrate-v9-to-v10]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v9-to-v10.md
+[migrate-v10-to-v11]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v10-to-v11.md
 [next-cache]: https://nextjs.org/docs/app/building-your-application/caching
 [next-docs]: https://nextjs.org/docs
 [next-revalidate-docs]: https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate


### PR DESCRIPTION
BREAKING CHANGE: See the migration guide: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v10-to-v11.md
