### PR TITLE
fix(experimental): just refresh in draft mode

### DIFF
--- a/packages/next-sanity/EXPERIMENTAL-CACHE-COMPONENTS.md
+++ b/packages/next-sanity/EXPERIMENTAL-CACHE-COMPONENTS.md
@@ -10,6 +10,26 @@ See the personal website template for a working example:
 - [Code](https://github.com/sanity-io/template-nextjs-personal-website/tree/test-cache-components)
 - [Demo](https://template-nextjs-personal-website-git-test-cache-components.sanity.dev/)
 
+```diff
+// ./src/lib/sanity/live.ts
+-import {defineLive} from 'next-sanity/experimental/live'
++import {defineLive} from 'next-sanity/live'
+```
+
+```diff
+// ./next.config.ts
+
++ experimental: {
++   cacheComponents: true,
++    cacheLife: {
++      default: {
++       // Sanity Live handles on-demand revalidation, so the default 15min time based revalidation is too short
++       revalidate: 60 * 60 * 24 * 90, // 90 days
++      },
++   },
++ },
+```
+
 ## API Differences from `next-sanity/live`
 
 `defineLive({stega})` is no longer `true` by default.

--- a/packages/next-sanity/src/experimental/constants.ts
+++ b/packages/next-sanity/src/experimental/constants.ts
@@ -1,0 +1,2 @@
+export const PUBLISHED_SYNC_TAG_PREFIX = 'sp:'
+export const DRAFT_SYNC_TAG_PREFIX = 'sd:'


### PR DESCRIPTION
Bypass causes the cache to not be used anyway, no point in running a cache expiry for cache that isn't used
