### PR TITLE
docs: :memo: fix typegen path to avoid module resolution collision

### DIFF
--- a/.changeset/twelve-ties-wait.md
+++ b/.changeset/twelve-ties-wait.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": patch
+---
+
+Fix typegen path example to avoid naming collision with sanity/types/ directory


### PR DESCRIPTION
docs: fix typegen path to avoid module resolution collision

- Change generated types path from types.ts to sanity-types.ts
- Add warning about sanity/types/ directory collision
- Update import examples to use new path
- Prioritize CLI config method (v4.19.0+) over separate config file

The collision occurs because Node's module resolver prioritizes sanity/types.ts (file) over sanity/types/ (directory), breaking schema imports in projects that organize schemas in a types/ folder.

### Description

The current README recommends generating TypeScript types to `./sanity/types.ts`, which creates a naming collision with the `sanity/types/` directory pattern commonly used in Sanity projects for organizing schema definitions.

When both a file (`sanity/types.ts`) and directory (`sanity/types/`) exist, Node's module resolver prioritizes the file, causing imports like `import { schema } from './sanity/types'` to fail with confusing "export doesn't exist" errors.

This PR:
- Changes the example generated types path to `sanity-types.ts` to avoid the collision
- Adds a WARNING callout explaining why this matters and how to avoid it
- Updates the "Using query result types" section to use the new import path
- Makes the v4.19.0+ CLI config approach the primary documented method

This affects any developer following Sanity's scaffolding patterns, which often create a `sanity/types/` directory for schema organization.

### What to review

- **README.md changes in the "Generate TypeScript Types" section** - verify the new structure is clear and the warning is prominent
- **Import path update in "Using query result types"** - confirm the example matches the new generated file path
- **Overall flow** - does the documentation now prevent the collision issue while maintaining clarity?

The changes are documentation-only and don't affect any code functionality.

### Testing

Documentation change only - no automated tests needed.

Tested by:
- Following the updated instructions in a fresh Next.js + Sanity project with a `sanity/types/` directory
- Verifying that generating to `sanity-types.ts` eliminates the module resolution error
- Confirming imports work correctly with the new path pattern

This pattern is currently working in production environments that encountered and resolved this exact issue.