### PR TITLE
fix(live): use client-side refresh for reconnect events with cacheComponents

### DIFF
--- a/packages/next-sanity/src/live/client-components/SanityLive.tsx
+++ b/packages/next-sanity/src/live/client-components/SanityLive.tsx
@@ -137,7 +137,13 @@ function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         startTransition(() => setRefreshOnInterval(false))
 
         if (onRestart) {
-          startTransition(() => onRestart(event, actionContext))
+          startTransition(() =>
+            Promise.resolve(onRestart(event, actionContext)).then((result) => {
+              if (result === 'refresh') {
+                startTransition(() => router.refresh())
+              }
+            }),
+          )
         }
         break
       }
@@ -146,7 +152,13 @@ function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         startTransition(() => setRefreshOnInterval(false))
 
         if (onReconnect) {
-          startTransition(() => onReconnect(event, actionContext))
+          startTransition(() =>
+            Promise.resolve(onReconnect(event, actionContext)).then((result) => {
+              if (result === 'refresh') {
+                startTransition(() => router.refresh())
+              }
+            }),
+          )
         }
         break
       }

--- a/packages/next-sanity/src/live/server-actions/index.next-js.ts
+++ b/packages/next-sanity/src/live/server-actions/index.next-js.ts
@@ -29,7 +29,11 @@ export async function actionUpdateTags(unsafeTags: unknown): Promise<void> {
 
 /**
  * Used by `<SanityLive onReconnect={actionRefresh} onRestart={actionRefresh} />`
+ *
+ * Returns `'refresh'` to signal the client component to call `router.refresh()`
+ * instead of triggering a server-side `refresh()`. This avoids a full page reload
+ * on dynamic catch-all routes where server-side `refresh()` causes a hard navigation.
  */
-export async function actionRefresh(): Promise<void> {
-  refresh()
+export async function actionRefresh(): Promise<'refresh'> {
+  return 'refresh'
 }

--- a/packages/next-sanity/src/live/shared/types.ts
+++ b/packages/next-sanity/src/live/shared/types.ts
@@ -81,14 +81,14 @@ export type SanityLiveOnWelcome = (
 export type SanityLiveOnReconnect = (
   event: Extract<LiveEvent, {type: 'reconnect'}>,
   context: SanityLiveActionContext,
-) => void | Promise<void>
+) => void | 'refresh' | Promise<void | 'refresh'>
 /**
  * TODO: docs
  */
 export type SanityLiveOnRestart = (
   event: Extract<LiveEvent, {type: 'restart'}>,
   context: SanityLiveActionContext,
-) => void | Promise<void>
+) => void | 'refresh' | Promise<void | 'refresh'>
 /**
  * TODO: docs
  * This event is fired when the API has hit the limit of concurrent connections, and the API will not deliver live events, in this case long polling intervals is a possible fallback strategy.


### PR DESCRIPTION
## Summary
- Fixes SAPP-3619: Pages using `SanityLive` with `cacheComponents: true` on catch-all routes would refresh on every tab focus change
- Root cause: EventSource reconnect/restart handlers were calling `refresh()` from `next/cache` (server-side full page refresh), which busts the entire page cache and triggers hard re-renders on dynamic catch-all routes
- Changed to return `'refresh'` signal and use `router.refresh()` from `next/navigation` (client-side in-place RSC re-render) which preserves scroll position
- Updated type definitions for `SanityLiveOnReconnect` and `SanityLiveOnRestart`

## Test plan
- [x] All 24 tests pass
- [x] TypeScript type-checking passes
- [x] Build + publint succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)