### PR TITLE
fix: upstream fixes from `cache-components` branch to `main`

### DIFF
--- a/.changeset/clean-groups-return.md
+++ b/.changeset/clean-groups-return.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": patch
+---
+
+Automatically disable long polling when <SanityLive> receives a `reconnect` or `restart` event

--- a/.changeset/floppy-melons-follow.md
+++ b/.changeset/floppy-melons-follow.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": patch
+---
+
+Stop calling `prefetchDNS` from 'react-dom' in `<SanityLive>`, calling `preconnect` is enough

--- a/.changeset/perky-grapes-show.md
+++ b/.changeset/perky-grapes-show.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": patch
+---
+
+Wrap `router.refresh()` in `startTransition`

--- a/packages/next-sanity/src/live/client-components/RefreshOnFocus.tsx
+++ b/packages/next-sanity/src/live/client-components/RefreshOnFocus.tsx
@@ -1,5 +1,5 @@
 import {useRouter} from 'next/navigation'
-import {useEffect} from 'react'
+import {startTransition, useEffect} from 'react'
 
 const focusThrottleInterval = 5_000
 
@@ -12,7 +12,7 @@ export default function RefreshOnFocus(): null {
     const callback = () => {
       const now = Date.now()
       if (now > nextFocusRevalidatedAt && document.visibilityState !== 'hidden') {
-        router.refresh()
+        startTransition(() => router.refresh())
         nextFocusRevalidatedAt = now + focusThrottleInterval
       }
     }

--- a/packages/next-sanity/src/live/client-components/RefreshOnInterval.tsx
+++ b/packages/next-sanity/src/live/client-components/RefreshOnInterval.tsx
@@ -1,0 +1,14 @@
+import {useRouter} from 'next/navigation'
+import {startTransition, useEffect} from 'react'
+
+export default function RefreshOnInterval(props: {interval: number}): null {
+  const router = useRouter()
+
+  useEffect(() => {
+    const interval = setInterval(() => startTransition(() => router.refresh()), props.interval)
+    return () => clearInterval(interval)
+  }, [router, props.interval])
+
+  return null
+}
+RefreshOnInterval.displayName = 'RefreshOnInterval'

--- a/packages/next-sanity/src/live/client-components/RefreshOnMount.tsx
+++ b/packages/next-sanity/src/live/client-components/RefreshOnMount.tsx
@@ -6,7 +6,7 @@
  */
 
 import {useRouter} from 'next/navigation'
-import {useEffect, useReducer} from 'react'
+import {useEffect, useReducer, startTransition} from 'react'
 
 export default function RefreshOnMount(): null {
   const router = useRouter()
@@ -14,8 +14,10 @@ export default function RefreshOnMount(): null {
 
   useEffect(() => {
     if (!mounted) {
-      mount()
-      router.refresh()
+      startTransition(() => {
+        mount()
+        router.refresh()
+      })
     }
   }, [mounted, router])
 

--- a/packages/next-sanity/src/live/client-components/RefreshOnReconnect.tsx
+++ b/packages/next-sanity/src/live/client-components/RefreshOnReconnect.tsx
@@ -1,5 +1,5 @@
 import {useRouter} from 'next/navigation'
-import {useEffect} from 'react'
+import {startTransition, useEffect} from 'react'
 
 export default function RefreshOnReconnect(): null {
   const router = useRouter()
@@ -7,7 +7,10 @@ export default function RefreshOnReconnect(): null {
   useEffect(() => {
     const controller = new AbortController()
     const {signal} = controller
-    window.addEventListener('online', () => router.refresh(), {passive: true, signal})
+    window.addEventListener('online', () => startTransition(() => router.refresh()), {
+      passive: true,
+      signal,
+    })
     return () => controller.abort()
   }, [router])
 

--- a/packages/next-sanity/src/live/client-components/SanityLive.tsx
+++ b/packages/next-sanity/src/live/client-components/SanityLive.tsx
@@ -10,7 +10,7 @@ import {isMaybePresentation, isMaybePreviewWindow} from '@sanity/presentation-co
 import {revalidateSyncTags as defaultRevalidateSyncTags} from 'next-sanity/live/server-actions'
 import dynamic from 'next/dynamic'
 import {useRouter} from 'next/navigation'
-import {useEffect, useMemo, useRef, useState, useEffectEvent} from 'react'
+import {useEffect, useMemo, useRef, useState, useEffectEvent, startTransition} from 'react'
 
 import {isCorsOriginError} from '#live/isCorsOriginError'
 
@@ -157,11 +157,11 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         router.refresh()
       } else {
         void revalidateSyncTags(event.tags).then((result) => {
-          if (result === 'refresh') router.refresh()
+          if (result === 'refresh') startTransition(() => router.refresh())
         })
       }
     } else if (event.type === 'restart' || event.type === 'reconnect') {
-      router.refresh()
+      startTransition(() => router.refresh())
     } else if (event.type === 'goaway') {
       onGoAway(event, intervalOnGoAway)
       setLongPollingInterval(intervalOnGoAway)
@@ -270,7 +270,7 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
    */
   useEffect(() => {
     if (!longPollingInterval) return
-    const interval = setInterval(() => router.refresh(), longPollingInterval)
+    const interval = setInterval(() => startTransition(() => router.refresh()), longPollingInterval)
     return () => clearInterval(interval)
   }, [longPollingInterval, router])
 

--- a/packages/next-sanity/src/live/client-components/SanityLive.tsx
+++ b/packages/next-sanity/src/live/client-components/SanityLive.tsx
@@ -88,10 +88,7 @@ function handleOnGoAway(event: LiveEventGoAway, intervalOnGoAway: number | false
   }
 }
 
-/**
- * @public
- */
-export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
+function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
   const {
     projectId,
     dataset,
@@ -291,3 +288,5 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
 }
 
 SanityLive.displayName = 'SanityLiveClientComponent'
+
+export default SanityLive

--- a/packages/next-sanity/src/live/client-components/SanityLive.tsx
+++ b/packages/next-sanity/src/live/client-components/SanityLive.tsx
@@ -16,10 +16,11 @@ import {isCorsOriginError} from '#live/isCorsOriginError'
 
 import {setEnvironment, setPerspective} from '../hooks/context'
 
-const PresentationComlink = dynamic(() => import('./PresentationComlink'), {ssr: false})
-const RefreshOnMount = dynamic(() => import('./RefreshOnMount'), {ssr: false})
-const RefreshOnFocus = dynamic(() => import('./RefreshOnFocus'), {ssr: false})
-const RefreshOnReconnect = dynamic(() => import('./RefreshOnReconnect'), {ssr: false})
+const PresentationComlink = dynamic(() => import('./PresentationComlink'))
+const RefreshOnMount = dynamic(() => import('./RefreshOnMount'))
+const RefreshOnInterval = dynamic(() => import('./RefreshOnInterval'))
+const RefreshOnFocus = dynamic(() => import('./RefreshOnFocus'))
+const RefreshOnReconnect = dynamic(() => import('./RefreshOnReconnect'))
 
 /**
  * @public
@@ -132,7 +133,7 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
       }),
     [apiHost, apiVersion, dataset, projectId, requestTagPrefix, token, useProjectHostname],
   )
-  const [longPollingInterval, setLongPollingInterval] = useState<number | false>(false)
+  const [refreshOnInterval, setRefreshOnInterval] = useState<number | false>(false)
 
   /**
    * 1. Handle Live Events and call revalidateTag or router.refresh when needed
@@ -150,7 +151,7 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
             : 'automatic revalidation of published content',
       )
       // Disable long polling when welcome event is received, this is a no-op if long polling is already disabled
-      setLongPollingInterval(false)
+      startTransition(() => setRefreshOnInterval(false))
     } else if (event.type === 'message') {
       if (waitFor === 'function') {
         // Cache is already revalidated by the Sanity Function, just refresh the router
@@ -161,10 +162,13 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         })
       }
     } else if (event.type === 'restart' || event.type === 'reconnect') {
+      // Disable long polling when restart/reconnect event is received, this is a no-op if long polling is already disabled
+      startTransition(() => setRefreshOnInterval(false))
+      // @TODO add support for `onRestart` and `onReconnect` events so this can be customized
       startTransition(() => router.refresh())
     } else if (event.type === 'goaway') {
       onGoAway(event, intervalOnGoAway)
-      setLongPollingInterval(intervalOnGoAway)
+      startTransition(() => setRefreshOnInterval(intervalOnGoAway))
     }
   })
   useEffect(() => {
@@ -265,15 +269,6 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
     }
   }, [draftModeEnabled])
 
-  /**
-   * 6. Handle switching to long polling when needed
-   */
-  useEffect(() => {
-    if (!longPollingInterval) return
-    const interval = setInterval(() => startTransition(() => router.refresh()), longPollingInterval)
-    return () => clearInterval(interval)
-  }, [longPollingInterval, router])
-
   return (
     <>
       {draftModeEnabled && loadComlink && (
@@ -286,8 +281,13 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         />
       )}
       {!draftModeEnabled && refreshOnMount && <RefreshOnMount />}
+      {refreshOnInterval && Number.isFinite(refreshOnInterval) && refreshOnInterval > 0 && (
+        <RefreshOnInterval interval={refreshOnInterval} />
+      )}
       {!draftModeEnabled && refreshOnFocus && <RefreshOnFocus />}
       {!draftModeEnabled && refreshOnReconnect && <RefreshOnReconnect />}
     </>
   )
 }
+
+SanityLive.displayName = 'SanityLiveClientComponent'

--- a/packages/next-sanity/src/live/client-components/index.ts
+++ b/packages/next-sanity/src/live/client-components/index.ts
@@ -1,4 +1,4 @@
 'use client'
 
 export type {SanityLiveProps} from './SanityLive'
-export {SanityLive as default} from './SanityLive'
+export {default} from './SanityLive'

--- a/packages/next-sanity/src/live/conditions/react-server/defineLive.tsx
+++ b/packages/next-sanity/src/live/conditions/react-server/defineLive.tsx
@@ -11,7 +11,7 @@ import {perspectiveCookieName} from '@sanity/preview-url-secret/constants'
 import SanityLiveClientComponent from 'next-sanity/live/client-components'
 import {PHASE_PRODUCTION_BUILD} from 'next/constants'
 import {draftMode, cookies} from 'next/headers'
-import {prefetchDNS, preconnect} from 'react-dom'
+import {preconnect} from 'react-dom'
 
 import {sanitizePerspective} from '#live/sanitizePerspective'
 
@@ -269,10 +269,9 @@ export function defineLive(config: DefineSanityLiveOptions): {
       client.config()
     const {isEnabled: isDraftModeEnabled} = await draftMode()
 
-    // Preconnect to the Live Event API origin, or at least prefetch the DNS if preconenct is not supported
+    // Preconnect to the Live Event API origin early, as the Sanity API is almost always on a different origin than the app
     const {origin} = new URL(client.getUrl('', false))
     preconnect(origin)
-    prefetchDNS(origin)
 
     return (
       <SanityLiveClientComponent


### PR DESCRIPTION
Upstreams fixes from `cache-components` #3109 to `main` that are not strictly required/needed for `cacheComponents: true` support.
