### PR TITLE
fix(live): change tag revalidation behavior in draft mode

### DIFF
--- a/.changeset/quiet-falcons-spark.md
+++ b/.changeset/quiet-falcons-spark.md
@@ -1,0 +1,37 @@
+---
+'next-sanity': minor
+---
+
+Change `<SanityLive />`'s default `revalidateSyncTags` behavior so draft mode revalidates affected Sanity tags with `revalidateTag(tag, 'max')`, instead of expiring them immediately with `revalidateTag(tag, {expire: 0})`.
+
+Technically this is a breaking change for apps relying on the previous immediate tag expiry behavior. However, because of the Next.js regression reported by Sanity to Vercel in https://github.com/vercel/next.js/issues/93210, we feel strongly that the default behavior in `<SanityLive />` needs to avoid `revalidateTag(tag, {expire: 0})` in draft mode: calling it worsens the impact of the regression by causing many `CACHE: REVALIDATED` events, which can massively increase ISR Writes.
+
+The previous behavior can be restored by providing a custom `revalidateSyncTags` prop to `<SanityLive />`:
+
+```tsx
+import type {SyncTag} from '@sanity/client'
+import {revalidateTag} from 'next/cache'
+
+import {SanityLive} from '@/sanity/live'
+
+async function revalidateSyncTags(tags: SyncTag[]): Promise<void> {
+  'use server'
+
+  revalidateTag('sanity:fetch-sync-tags', 'max')
+
+  for (const _tag of tags) {
+    revalidateTag(`sanity:${_tag}`, {expire: 0})
+  }
+}
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive revalidateSyncTags={revalidateSyncTags} />
+      </body>
+    </html>
+  )
+}
+```

--- a/packages/next-sanity/src/live/server-actions/index.default.ts
+++ b/packages/next-sanity/src/live/server-actions/index.default.ts
@@ -2,20 +2,33 @@
 
 import type {ClientPerspective, SyncTag} from '@sanity/client'
 import {perspectiveCookieName} from '@sanity/preview-url-secret/constants'
-import {revalidateTag} from 'next/cache'
+import {revalidateTag, updateTag} from 'next/cache'
 import {cookies, draftMode} from 'next/headers'
 
 import {sanitizePerspective} from '#live/sanitizePerspective'
 
 export async function revalidateSyncTags(tags: SyncTag[]): Promise<void> {
-  revalidateTag('sanity:fetch-sync-tags', 'max')
+  const {isEnabled: isDraftMode} = await draftMode()
 
+  if (!isDraftMode) {
+    revalidateTag('sanity:fetch-sync-tags', 'max')
+  }
+
+  const logTags: string[] = []
   for (const _tag of tags) {
     const tag = `sanity:${_tag}`
-    revalidateTag(tag, {expire: 0})
-    // oxlint-disable-next-line no-console
-    console.log(`<SanityLive /> revalidated tag: ${tag}`)
+    if (isDraftMode) {
+      revalidateTag(tag, 'max')
+    } else {
+      updateTag(tag)
+    }
+    logTags.push(tag)
   }
+
+  // oxlint-disable-next-line no-console
+  console.log(
+    `<SanityLive /> ${isDraftMode ? `revalidated tags: ${logTags.join(', ')} with cache profile "max" ` : `updated tags: ${logTags.join(', ')} and revalidated tag: "sanity:fetch-sync-tags" with cache profile "max"`}`,
+  )
 }
 
 export async function setPerspectiveCookie(perspective: ClientPerspective): Promise<void> {


### PR DESCRIPTION
This change is to mitigate https://github.com/vercel/next.js/issues/93210, at least for draft mode. It will be fully mitigated in the next major when #3109 with the default behavior having a breaking change that will be documented, with guidance for which implementation to use `updateTag(tag)` vs `revalidateTag(tag, 'max')` vs [sync tag invalidate functions](https://www.sanity.io/docs/changelog/7a491dd1-67e8-41e0-9a89-eb9704055dc6)