### PR TITLE
fix: prevent accidental `cacheComponents: true` usage

### DIFF
--- a/.changeset/silent-planes-wait.md
+++ b/.changeset/silent-planes-wait.md
@@ -1,0 +1,7 @@
+---
+'next-sanity': minor
+---
+
+Disallow using `defineLive` when `cacheComponents: true` is enabled.
+
+Technically this is a breaking change for apps that currently combine `defineLive` with Next.js Cache Components. However, this configuration is not supported and can cause problems that are difficult to detect, so it is better to fail early until #3109 lands.

--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -42,6 +42,7 @@
     "./hooks": "./src/hooks/index.ts",
     "./image": "./src/image/index.ts",
     "./live": {
+      "next-js": "./src/live/conditions/next-js/index.ts",
       "react-server": "./src/live/conditions/react-server/index.ts",
       "default": "./src/live/conditions/default/index.ts"
     },
@@ -64,6 +65,7 @@
       "./hooks": "./dist/hooks/index.js",
       "./image": "./dist/image/index.js",
       "./live": {
+        "next-js": "./dist/live/conditions/next-js/index.js",
         "react-server": "./dist/live/conditions/react-server/index.js",
         "default": "./dist/live/conditions/default/index.js"
       },

--- a/packages/next-sanity/src/live/conditions/next-js/index.ts
+++ b/packages/next-sanity/src/live/conditions/next-js/index.ts
@@ -1,0 +1,22 @@
+import type {
+  DefineSanityLiveOptions,
+  DefinedSanityFetchType,
+  DefinedSanityLiveProps,
+} from '../react-server/defineLive'
+
+/**
+ * @public
+ */
+export function defineLive(_config: DefineSanityLiveOptions): {
+  sanityFetch: DefinedSanityFetchType
+  SanityLive: React.ComponentType<DefinedSanityLiveProps>
+} {
+  throw new Error('defineLive does not yet support `cacheComponents: true`. Wait for the next major version of next-sanity, or use the prerelease with `pnpm install next-sanity@cache-components`')
+}
+
+/**
+ * @public
+ */
+export type {DefineSanityLiveOptions, DefinedSanityFetchType, DefinedSanityLiveProps}
+
+export {isCorsOriginError} from '#live/isCorsOriginError'

--- a/packages/next-sanity/tsdown.config.ts
+++ b/packages/next-sanity/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     './src/hooks/index.ts',
     './src/image/index.ts',
     './src/index.ts',
+    './src/live/conditions/next-js/index.ts',
     './src/live/conditions/react-server/index.ts',
     './src/live/conditions/default/index.ts',
     './src/live/client-components/index.ts',
@@ -54,10 +55,12 @@ export default defineConfig({
       delete pkg['./package.json']
 
       pkg['./live'] = {
+        'next-js': pkg['./live/conditions/next-js'],
         'react-server': pkg['./live/conditions/react-server'],
         'default': pkg['./live/conditions/default'],
       }
       delete pkg['./live/conditions/default']
+      delete pkg['./live/conditions/next-js']
       delete pkg['./live/conditions/react-server']
 
       pkg['./live/server-actions'] = {


### PR DESCRIPTION
Using `defineLive` with `cacheComponents: true` is not supported, doing so causes problems that are difficult to detect so it's best to disallow it until #3109 lands