### PR TITLE
docs(changesets): align imports with docs and tighten prose

### DIFF
--- a/.changeset/blue-dryers-juggle.md
+++ b/.changeset/blue-dryers-juggle.md
@@ -7,8 +7,8 @@ Allow enabling `stega: true` on `sanityFetch` if `serverToken` is provided
 Previously, if you tried to enable stega on `perspective: 'published'` it would not work:
 
 ```ts
-const {data} =await sanityFetch({query, params: perspective: 'published', stega: true})
+const {data} = await sanityFetch({query, params, perspective: 'published', stega: true})
 // data has no stega
 ```
 
-Now it does, allowing you to show visual editing overlays on published content. This is especially useful when using features like [Vercel's Content Link](https://vercel.com/docs/edit-mode#content-link).
+Now it does, allowing you to show Visual Editing overlays on published content. This is especially useful when using features like [Vercel's Content Link](https://vercel.com/docs/edit-mode#content-link).

--- a/.changeset/clear-dingos-beg.md
+++ b/.changeset/clear-dingos-beg.md
@@ -2,4 +2,4 @@
 'next-sanity': minor
 ---
 
-Add `onRestart` prop on `<SanityLive>`, by default it calls `router.refresh()`. You can set `<SanityLive onRestart={false} />` to disable the default behavior.
+Add `onRestart` prop to `<SanityLive>`. By default it calls `router.refresh()`; pass `onRestart={false}` to disable.

--- a/.changeset/cute-stamps-return.md
+++ b/.changeset/cute-stamps-return.md
@@ -4,7 +4,7 @@
 
 Add `onError="throw"` opt-in for `<SanityLive>`
 
-The default still logs errors with `console.error` (CORS errors use `console.warn` and include the blocked origin), matching `next-sanity@12`.
+The default behavior still logs errors with `console.error` (CORS errors use `console.warn` and include the blocked origin), matching `next-sanity@12`.
 
 Pass `onError="throw"` to throw errors during render so they can be caught by the [unstable_catchError API](https://nextjs.org/docs/app/api-reference/functions/catchError), which supports `unstable_retry` for retrying the render.
 

--- a/.changeset/cute-stamps-return.md
+++ b/.changeset/cute-stamps-return.md
@@ -4,9 +4,9 @@
 
 Add `onError="throw"` opt-in for `<SanityLive>`
 
-The default behavior remains to log errors with `console.error` (CORS errors are logged with `console.warn` including the blocked origin). This matches the `next-sanity@12` behavior.
+The default still logs errors with `console.error` (CORS errors use `console.warn` and include the blocked origin), matching `next-sanity@12`.
 
-You can now pass `onError="throw"` to throw errors during render so they can be caught by the [unstable_catchError API](https://nextjs.org/docs/app/api-reference/functions/catchError) which supports `unstable_retry` for retrying the render.
+Pass `onError="throw"` to throw errors during render so they can be caught by the [unstable_catchError API](https://nextjs.org/docs/app/api-reference/functions/catchError), which supports `unstable_retry` for retrying the render.
 
 #### Custom error handler
 
@@ -36,7 +36,7 @@ Then in your `layout.tsx` file, import the `onError` function and pass it to `<S
 ```tsx
 // app/layout.tsx
 import {onError} from './client-functions'
-import {SanityLive} from '#sanity/live'
+import {SanityLive} from '@/sanity/lib/live'
 
 export default function Layout({children}: {children: React.ReactNode}) {
   return (
@@ -50,7 +50,7 @@ export default function Layout({children}: {children: React.ReactNode}) {
 
 #### Customize the error boundary
 
-Using the [unstable_catchError API](https://nextjs.org/docs/app/api-reference/functions/catchError) you can create an error boundary that can handle errors and offer retry logic. Here's an example that uses the `sonner` library to show error toasts that adapt to the error type:
+Using the [unstable_catchError API](https://nextjs.org/docs/app/api-reference/functions/catchError), you can create an error boundary that handles errors and offers retry logic. Here's an example that uses the `sonner` library to show error toasts that adapt to the error type:
 
 ```tsx
 // app/SanityLiveErrorBoundary.tsx
@@ -109,12 +109,12 @@ function SanityLiveErrorBoundary(_props: {}, {error, unstable_retry}: ErrorInfo)
 export default unstable_catchError(SanityLiveErrorBoundary)
 ```
 
-Then in your `layout.tsx` file wrap the `SanityLive` component in the error boundary:
+Then in your `layout.tsx` file, wrap the `SanityLive` component in the error boundary:
 
 ```tsx
 // app/layout.tsx
 import SanityLiveErrorBoundary from './SanityLiveErrorBoundary'
-import {SanityLive} from '#sanity/live'
+import {SanityLive} from '@/sanity/lib/live'
 
 export default function Layout({children}: {children: React.ReactNode}) {
   return (

--- a/.changeset/easy-pianos-yawn.md
+++ b/.changeset/easy-pianos-yawn.md
@@ -4,4 +4,4 @@
 
 Don't call `draftMode()` in `<SanityLive>` if no `browserToken` is set
 
-Without a `browserToken` then `includeDrafts` won't have an effect, so there's no need to call `draftMode()` in that case.
+Without a `browserToken`, `includeDrafts` has no effect, so there's no reason to call `draftMode()`.

--- a/.changeset/icy-deer-lead.md
+++ b/.changeset/icy-deer-lead.md
@@ -4,4 +4,4 @@
 
 `sanityFetch` no longer calls `draftMode()` unless a `serverToken` is provided.
 
-If no `serverToken` then there's no special handling of resolving `perspective` and `stega` options when in draft mode, so there's no need to call `draftMode()`, which can cause issues in certain environments.
+Without a `serverToken`, `perspective` and `stega` aren't adjusted for draft mode, so the `draftMode()` call is unnecessary and can cause issues in certain environments.

--- a/.changeset/pretty-chicken-hear.md
+++ b/.changeset/pretty-chicken-hear.md
@@ -2,4 +2,4 @@
 'next-sanity': minor
 ---
 
-Add `onReconnect` prop on `<SanityLive>`, by default it logs an error to the console. You can set `<SanityLive onReconnect={false} />` to disable the default behavior.
+Add `onReconnect` prop to `<SanityLive>`. By default it logs an error to the console; pass `onReconnect={false}` to disable.

--- a/.changeset/ripe-seals-sin.md
+++ b/.changeset/ripe-seals-sin.md
@@ -4,15 +4,14 @@
 
 Add `resolvePerspectiveFromCookies` utility
 
-When `cacheComponents: false` the `sanityFetch` function returned by `defineLive` will automatically resolve the `perspective` when in [draft mode](https://nextjs.org/docs/app/guides/draft-mode).
-The way it resolves it is by reading a cookie that is set by the `defineEnableDraftMode` function, and updated by `Presentation Tool` when the user switches perspectives in the Studio.
+When `cacheComponents: false`, `sanityFetch` automatically resolves the `perspective` in [draft mode](https://nextjs.org/docs/app/guides/draft-mode) by reading a cookie that `defineEnableDraftMode` sets and that Presentation Tool updates when the user switches perspectives in the Studio.
 
-The `resolvePerspectiveFromCookies` utility allows you to resolve the `perspective` in the same way so you can:
+The new `resolvePerspectiveFromCookies` utility exposes that resolution directly, so you can:
 
-- Instrument draft mode with a custom toolbar that lists which perspectives are currently used to fetch data on the page.
-- Resolve `perspective` the same way in `cacheComponents: true` components, providing it as input to `'use cache'` boundaries that call `sanityFetch`.
+- Instrument draft mode with a custom toolbar that lists the perspectives currently used to fetch data on the page.
+- Resolve `perspective` in `cacheComponents: true` components and pass it into `'use cache'` boundaries that call `sanityFetch`.
 
-Here's how to call it the same way that `sanityFetch` does:
+Here's how `sanityFetch` resolves it internally — wrap it in a helper to do the same:
 
 ```tsx
 import {cookies, draftMode} from 'next/headers'

--- a/.changeset/salty-cows-enjoy.md
+++ b/.changeset/salty-cows-enjoy.md
@@ -4,5 +4,4 @@
 
 Never set `resultSourceMap` for `fetch-sync-tags` requests in `sanityFetch`
 
-Previously if `client.config()` is set to `'withKeyArraySelector'` or `true` it would return content source maps for both underlying `client.fetch()` requests that `sanityFetch()` makes.
-However, it's only needed for the second request, as the first request never returns content source maps.
+Previously, if the `client` had `resultSourceMap` set to `'withKeyArraySelector'` or `true`, both `client.fetch()` calls inside `sanityFetch()` would request content source maps. The first call (a `fetch-sync-tags` request) never returns them, so it now omits the option.

--- a/.changeset/shy-banks-draw.md
+++ b/.changeset/shy-banks-draw.md
@@ -2,6 +2,6 @@
 'next-sanity': minor
 ---
 
-Refactor `usePresentationQuery` to use `<VisualEditing />` as the provider, instead of `<SanityLive />`
+Refactor `usePresentationQuery` to use `<VisualEditing />` as the provider instead of `<SanityLive />`
 
 `usePresentationQuery` now only requires `<VisualEditing />`; `<SanityLive />` is no longer needed on the page.

--- a/.changeset/sixty-ties-pick.md
+++ b/.changeset/sixty-ties-pick.md
@@ -4,4 +4,4 @@
 
 Add `includeDrafts` prop to `<SanityLive />`
 
-When you pass `browserToken` to `defineLive`, `<SanityLive />` automatically sets [`client.live.events` `includeDrafts`](https://www.sanity.io/docs/apis-and-sdks/js-client-realtime#ccdcec9ba7c4) from `draftMode().isEnabled`. The new `includeDrafts` prop lets you override that.
+When you pass `browserToken` to `defineLive`, `<SanityLive />` automatically sets [`client.live.events` `includeDrafts`](https://www.sanity.io/docs/apis-and-sdks/js-client-realtime#ccdcec9ba7c4) based on whether draft mode is enabled. The new `includeDrafts` prop lets you override that.

--- a/.changeset/sixty-ties-pick.md
+++ b/.changeset/sixty-ties-pick.md
@@ -4,4 +4,4 @@
 
 Add `includeDrafts` prop to `<SanityLive />`
 
-When you pass `browserToken` to `defineLive`, `<SanityLive />` automatically sets [`client.live.events` `includeDrafts`](https://www.sanity.io/docs/apis-and-sdks/js-client-realtime#ccdcec9ba7c4) from `draftMode().isEnabled`. You can now override that by setting the `includeDrafts` prop directly.
+When you pass `browserToken` to `defineLive`, `<SanityLive />` automatically sets [`client.live.events` `includeDrafts`](https://www.sanity.io/docs/apis-and-sdks/js-client-realtime#ccdcec9ba7c4) from `draftMode().isEnabled`. The new `includeDrafts` prop lets you override that.

--- a/.changeset/slimy-cougars-sing.md
+++ b/.changeset/slimy-cougars-sing.md
@@ -13,5 +13,5 @@ npx skills add https://github.com/sanity-io/next-sanity --skill sanity-live-cach
 Suggested prompt:
 
 ```txt
-Use the /sanity-live-cache-components skill to migrate this app to use cache components. When verifying with `next dev`, test both draft mode enabled and draft mode disabled because each mode has different rendering rules. `next build --debug-prerender` is not sufficient to verify that draft mode works correctly.
+Use the /sanity-live-cache-components skill to migrate this app to use Cache Components. When verifying with `next dev`, test both draft mode enabled and draft mode disabled because each mode has different rendering rules. `next build --debug-prerender` is not sufficient to verify that draft mode works correctly.
 ```

--- a/.changeset/slimy-cougars-sing.md
+++ b/.changeset/slimy-cougars-sing.md
@@ -4,14 +4,14 @@
 
 Add support for `cacheComponents: true` with `defineLive`
 
-You can use the `sanity-live-cache-components` skill to opt-in to cache components using an agent (assuming you have [`AGENTS.md` setup for optimal next.js agent performance](https://nextjs.org/docs/app/guides/ai-agents#existing-projects)):
+The `sanity-live-cache-components` skill can drive the migration with an agent. For best results, set up [`AGENTS.md`](https://nextjs.org/docs/app/guides/ai-agents#existing-projects) first.
 
 ```bash
 npx skills add https://github.com/sanity-io/next-sanity --skill sanity-live-cache-components
 ```
 
-Prompt:
+Suggested prompt:
 
 ```txt
-Use the /sanity-live-cache-components skill to migrate this app to use cache components. When verifying that the build works with `next dev` make sure you remember to test with draft mode enabled in nextjs as well as disabled as there are different rules for each mode, and running `next build --debug-prerender` is not enough to verify that draft mode works correctly.
+Use the /sanity-live-cache-components skill to migrate this app to use cache components. When verifying with `next dev`, test both draft mode enabled and draft mode disabled because each mode has different rendering rules. `next build --debug-prerender` is not sufficient to verify that draft mode works correctly.
 ```

--- a/.changeset/small-mammals-sink.md
+++ b/.changeset/small-mammals-sink.md
@@ -7,4 +7,4 @@ Add opt-in `strict` mode to `defineLive` so cache-components migrations can be s
 1. Enable `strict: true`, then update `sanityFetch` and `<SanityLive>` call sites to satisfy the new requirements.
 2. Enable `cacheComponents: true` in `next.config.ts` and add `'use cache'` to functions that call `sanityFetch`.
 
-Strict mode is only needed when migrating to cache components alongside Visual Editing or Presentation Tool.
+Strict mode is only needed when migrating to cache-components alongside Visual Editing or Presentation Tool.

--- a/.changeset/small-mammals-sink.md
+++ b/.changeset/small-mammals-sink.md
@@ -2,9 +2,9 @@
 'next-sanity': minor
 ---
 
-Add opt-in `strict` mode to `defineLive` so cache-components migrations can be split across two PRs:
+Add opt-in `strict` mode to `defineLive` so [Cache Components](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) migrations can be split across two PRs:
 
 1. Enable `strict: true`, then update `sanityFetch` and `<SanityLive>` call sites to satisfy the new requirements.
 2. Enable `cacheComponents: true` in `next.config.ts` and add `'use cache'` to functions that call `sanityFetch`.
 
-Strict mode is only needed when migrating to cache-components alongside Visual Editing or Presentation Tool.
+Strict mode is only needed when migrating to [Cache Components](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) alongside Visual Editing or Presentation Tool.

--- a/.changeset/small-mammals-sink.md
+++ b/.changeset/small-mammals-sink.md
@@ -2,9 +2,9 @@
 'next-sanity': minor
 ---
 
-Add opt-in `strict` mode to `defineLive` to ease cache components adoption by splitting the migration into two PRs:
+Add opt-in `strict` mode to `defineLive` so cache-components migrations can be split across two PRs:
 
-1. Enable `strict: true` and update `sanityFetch` and `<SanityLive>` call sites to satisfy the stricter requirements.
+1. Enable `strict: true`, then update `sanityFetch` and `<SanityLive>` call sites to satisfy the new requirements.
 2. Enable `cacheComponents: true` in `next.config.ts` and add `'use cache'` to functions that call `sanityFetch`.
 
-You only need strict mode if you're migrating to cache components and use Visual Editing or Presentation Tool.
+Strict mode is only needed when migrating to cache components alongside Visual Editing or Presentation Tool.

--- a/.changeset/twenty-schools-stick.md
+++ b/.changeset/twenty-schools-stick.md
@@ -4,7 +4,7 @@
 
 Add `onWelcome` prop to `<SanityLive>`
 
-The default behavior is to log a welcome message to the console, here's how to customize it:
+The default behavior is to log a welcome message to the console. Here's how to customize it:
 
 ```tsx
 // app/client-functions.ts
@@ -22,7 +22,7 @@ export const onWelcome: SanityLiveOnWelcome = (event, {includeDrafts, waitFor}) 
 ```tsx
 // app/layout.tsx
 import {onWelcome} from './client-functions'
-import {SanityLive} from '#sanity/live'
+import {SanityLive} from '@/sanity/lib/live'
 
 export default function Layout({children}: {children: React.ReactNode}) {
   return (
@@ -34,4 +34,4 @@ export default function Layout({children}: {children: React.ReactNode}) {
 }
 ```
 
-To disable default welcome message, pass `onWelcome={false}`.
+To disable the default welcome message, pass `onWelcome={false}`.


### PR DESCRIPTION
## Summary

Pass over the non-major changesets in `.changeset/` to make code examples and prose consistent with the docs (`packages/next-sanity/EXPERIMENTAL-CACHE-COMPONENTS.md`, `MIGRATE-v10-to-v11.md`, `skills/sanity-live-cache-components/SKILL.md`).

- **Imports** — replaced the `'#sanity/live'` Node import-condition examples with the docs-style `'@/sanity/lib/live'` alias in [`cute-stamps-return.md`](.changeset/cute-stamps-return.md) (2x) and [`twenty-schools-stick.md`](.changeset/twenty-schools-stick.md).
- **Code fix** — repaired the broken `sanityFetch` example in [`blue-dryers-juggle.md`](.changeset/blue-dryers-juggle.md) (missing space after `=`, malformed `params:` field).
- **Typos & grammar** — fixed missing/stray commas, awkward `If no .../Without ... then` constructions, and capitalization of `Visual Editing` and `Next.js`. Corrected `client.config()` → `resultSourceMap` in [`salty-cows-enjoy.md`](.changeset/salty-cows-enjoy.md) (the actual config option being referenced).
- **Readability** — removed repetitive language (notably three `the same way`s in [`ripe-seals-sin.md`](.changeset/ripe-seals-sin.md), `request`/`behavior`/double-`default` repetitions elsewhere) and standardized the "Add `X` prop to `<SanityLive>`. By default it ...; pass `X={false}` to disable." shape across the prop-style minor changesets ([`clear-dingos-beg.md`](.changeset/clear-dingos-beg.md), [`pretty-chicken-hear.md`](.changeset/pretty-chicken-hear.md)).

Major changesets were intentionally left untouched.

## Test plan

- [x] Visually skim the rendered changesets after `changeset version` to confirm the changelog reads cleanly.
- [x] Sanity-check that no code example references a Node import-condition path (`'#sanity/live'`) anymore.


Made with [Cursor](https://cursor.com)