### PR TITLE
docs(skill): restructure sanity-live-cache-components for progressive disclosure

### DIFF
--- a/skills/sanity-live-cache-components/SKILL.md
+++ b/skills/sanity-live-cache-components/SKILL.md
@@ -1,38 +1,62 @@
 ---
 name: sanity-live-cache-components
-description: Migrate next-sanity apps to cacheComponents - strict mode, three-layer component pattern, explicit perspective/stega/includeDrafts, prop-drilling conventions
+description: Integrates Sanity Live with Next.js Cache Components in next-sanity v13+ apps. Sets up sanityFetch, <SanityLive>, Visual Editing, Presentation Tool, draft mode handling, and the three-layer (Page/Dynamic/Cached) component pattern with explicit perspective/stega prop-drilling. Use when configuring or migrating a Next.js app to cacheComponents with Sanity, when adding sanityFetch, when wiring <SanityLive>/<VisualEditing>, or when refactoring components that hardcode perspective/stega.
 ---
 
 # Sanity Live + Cache Components
 
-You are an expert in Next.js who's aware that your training data is likely outdated, always read the relevant guide in `node_modules/next/dist/docs/` (when available) before writing any code.
-If the guide conflicts with what is said in this skill, then follow this skill's instructions.
-You will be integrating Sanity Live into your Next.js app, so that data is fetched with `sanityFetch` which calls `cacheTag` and `cacheLife` internally, and a `<SanityLive />` component is rendered in the root layout that handles revalidating cached content in response to live events sent by Sanity Content Lake over an EventSource connection. Your integration is sophisticated and ensures it fully supports Visual Editing and Presentation Tool, which is enabled when Next.js is in draft mode.
+Wires `next-sanity` into a Next.js 16+ app with `cacheComponents: true`. Data is fetched with `sanityFetch` (which calls `cacheTag`/`cacheLife` internally), and `<SanityLive>` in the root layout revalidates cached content over an EventSource connection to Sanity Content Lake. Visual Editing and Presentation Tool are fully supported when draft mode is enabled.
+
+Read the relevant guide in `node_modules/next/dist/docs/` (when available) before writing code. If a guide conflicts with this skill, follow this skill.
+
+This skill assumes familiarity with the `next-cache-components` skill — it covers `'use cache'`, `cacheLife`, `cacheTag`, and the cookies/headers/params rule. The only Sanity-relevant exception: `await draftMode()` is allowed inside `'use cache'` (Next.js bypasses caching when draft mode is enabled — see [the `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode)).
 
 ## Prerequisites
 
-- You have upgraded to `next@16.2.x` or later.
-- You have set up `AGENTS.md`, if not [see the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
-- You have a working Next.js 16+ app with the following environment variables set up already:
+- Next.js 16.2+ (`pnpm view next version` or `npm view next version` to check).
+- `AGENTS.md` exists, or [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
+- These environment variables are set:
   - `NEXT_PUBLIC_SANITY_PROJECT_ID`
   - `NEXT_PUBLIC_SANITY_DATASET`
   - `SANITY_API_READ_TOKEN`
 
+## Reference files
+
+| File                                                          | When to read                                                                          |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [reference/live-helpers.md](reference/live-helpers.md)        | Full `client.ts` / `live.ts`, `sanityFetch*` and `getDynamicFetchOptions` details     |
+| [reference/three-layer-pattern.md](reference/three-layer-pattern.md) | The Page → Dynamic → Cached pattern for `page.tsx`, including the `searchParams` variant |
+| [reference/layouts.md](reference/layouts.md)                  | Non-blocking data fetching inside `layout.tsx` with a shared `'use cache'` helper     |
+| [reference/dynamic-segments.md](reference/dynamic-segments.md) | High-performance `[slug]` routes: `loading.tsx` + partial `generateStaticParams`, or non-blocking dynamic `params` in a layout |
+
 ---
 
-## 1. Upgrade to `next-sanity@latest`
-
-If `next-sanity@latest` isn't v13 yet then use `next-sanity@cache-components` instead, check with `npm dist-tag ls next-sanity`.
+## 1. Install `next-sanity@^13`
 
 ```bash
 npm install next-sanity@^13 --save-exact
 ```
 
+If `next-sanity@latest` isn't v13 yet, use `next-sanity@cache-components` instead. Check with `npm dist-tag ls next-sanity`.
+
+### Migrating an existing Sanity Live setup
+
+If the app is already using `defineLive`, this skill is a refactor, not a rewrite. The 5-step sequence below still applies, but watch for these specific differences:
+
+- **Don't overwrite `client.ts` or `live.ts`** if they exist. Append missing options. Preserve any existing `token` and `stega.*` settings — see [reference/live-helpers.md](reference/live-helpers.md).
+- **Search the codebase for hardcoded `perspective: 'published'` and `stega: false`** in `sanityFetch` callsites and refactor them to source `perspective`/`stega` via `getDynamicFetchOptions` and the three-layer pattern.
+- **Search for `sanityFetch` calls inside `generateStaticParams`** → swap for `sanityFetchStaticParams`.
+- **Search for `sanityFetch` calls inside `generateMetadata` / `sitemap.ts` / `opengraph-image.tsx` / etc.** → swap for `sanityFetchMetadata`.
+- **Search for `sanityFetch` calls directly inside a `'use server'` function** → split into a separate `'use cache'` helper.
+- **Verify there is exactly one `<SanityLive>` and one `<VisualEditing>` in the tree.** Multiple renders are undefined behavior.
+
+The "Anti-patterns to grep for" section at the bottom of this file lists the search patterns.
+
 ---
 
 ## 2. Configure `next.config.ts`
 
-The `cacheComponents` flag must be set to `true`, and it's also recommended to set `cacheLife.default` to `sanity` so that the default revalidation time is 1 year instead of 15 minutes, as `sanityFetch` is optimized for on-demand revalidation and does not need any time-based revalidation.
+Enable `cacheComponents` and set `cacheLife.default` to `sanity` so default revalidation is 1 year (instead of 15 minutes). `sanityFetch` is optimized for on-demand revalidation and doesn't need time-based revalidation.
 
 ```ts
 // next.config.ts
@@ -49,309 +73,37 @@ export default nextConfig
 
 ---
 
-## 3. Configure `defineLive` and export `sanityFetch`, `<SanityLive>`, and other helpers
+## 3. Configure `defineLive` and export helpers
 
-> **What dynamic APIs are allowed inside `'use cache'`?**
->
-> - **Allowed (sole exception):** `await draftMode()` — you can read `isEnabled` inside a `'use cache'` boundary. Next.js automatically bypasses caching when Draft Mode is enabled, so draft content stays fresh. See the [official `use cache` reference](https://nextjs.org/docs/app/api-reference/directives/use-cache#draft-mode).
-> - **Not allowed:** `await cookies()`, `await headers()`, `await props.params`, `await props.searchParams`, and any other request-bound dynamic API. These must be awaited outside the `'use cache'` boundary (typically in a `Dynamic*` wrapper) and passed in as plain serializable props.
-
-### `client.ts`
-
-Projects typically have a `src/sanity/lib/client.ts` file that exports a `const client = createClient({})`,
-it should look roughly like this:
+Create `src/sanity/lib/client.ts` and `src/sanity/lib/live.ts`. The minimal `defineLive` call:
 
 ```ts
-// src/sanity/lib/client.ts
-import {createClient} from 'next-sanity'
-
-export const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
-  useCdn: true,
-  apiVersion: '2026-05-19',
-  perspective: 'published',
-  stega: {studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || 'http://localhost:3333'},
-})
-```
-
-The `client.ts` file should use a modern `apiVersion` (for example today's date as a hardcoded string), and `stega: {studioUrl}` to enable stega encoding.
-`stega.studioUrl` can be a relative string if there's a route that renders an embedded Sanity Studio, using `NextStudio` from `next-sanity/studio`. Otherwise it could be an absolute URL, typically set by an environment variable.
-
-If the `client.ts` file already exists then don't overwrite it, extend it with options that are missing (append only from the above reference).
-Giving `apiVersion` a new value, or removing other `stega.*` options can lead to breakage.
-Never remove an existing `token` from `createClient`. Private datasets require a client token even for published-content fetches.
-
-### `live.ts`
-
-Create a `live.ts` file in the same directory as `client.ts` (unless it already exists, if so just add to it what's missing based on the below reference) that exports `sanityFetch`, `<SanityLive>`, and other helpers:
-
-```ts
-// src/sanity/lib/live.ts
-import {type QueryParams} from 'next-sanity'
-import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
-import {cookies, draftMode} from 'next/headers'
-import {client} from './client'
-
-const token = process.env.SANITY_API_READ_TOKEN
-if (!token) {
-  throw new Error('Missing SANITY_API_READ_TOKEN')
-}
-
+// src/sanity/lib/live.ts (excerpt)
 export const {SanityLive, sanityFetch} = defineLive({
   client,
   serverToken: token,
   browserToken: token,
   strict: true,
 })
-
-export interface DynamicFetchOptions {
-  perspective: LivePerspective
-  stega: boolean
-}
-export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
-  const {isEnabled: isDraftMode} = await draftMode()
-  if (!isDraftMode) {
-    return {perspective: 'published', stega: false}
-  }
-
-  const jar = await cookies()
-  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
-  return {perspective: perspective ?? 'drafts', stega: true}
-}
-
-// For usage within `generateStaticParams`
-export async function sanityFetchStaticParams<const QueryString extends string>({
-  query,
-  params = {},
-}: {
-  query: QueryString
-  params?: QueryParams
-}) {
-  'use cache'
-  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
-  return {data}
-}
-
-// For usage within `generateMetadata` and `generateViewport`
-export async function sanityFetchMetadata<const QueryString extends string>({
-  query,
-  params = {},
-  perspective,
-}: {
-  query: QueryString
-  params?: QueryParams
-  perspective: LivePerspective
-}) {
-  'use cache'
-  const {data} = await sanityFetch({query, params, perspective, stega: false})
-  return {data}
-}
 ```
 
-#### `sanityFetch`
+Full file contents (including `client.ts`, `getDynamicFetchOptions`, `sanityFetchMetadata`, `sanityFetchStaticParams`) and per-helper guidance: [reference/live-helpers.md](reference/live-helpers.md).
 
-For fetching data in React Server Components that have `'use cache'` directives and are eventually rendered in a `page.tsx` or `layout.tsx`.
-The `stega` option is for Visual Editing support: when `stega: true`, with `stega.studioUrl` set in `createClient`, and with `<VisualEditing />` rendered in a root layout, this will render click-to-edit overlays on top of content.
+The helpers exported from `live.ts`:
 
-- The `perspective` option is for switching between published and draft content, and specific Sanity Content Releases.
-- The `getDynamicFetchOptions` helper also ensures that `perspective` is resolved from the `'sanity-preview-perspective'` cookie. This cookie is managed by `<VisualEditing>` when the app is rendered in a preview iframe within Presentation Tool in a Sanity Studio. The user can change which content release to preview, and the iframe automatically updates to show the content for the selected content release.
-
-Any async function that calls `sanityFetch` should have a `'use cache'` or `'use cache: remote'` directive.
-That async function boundary should take `perspective` and `stega` options as props. It should never hardcode them to `perspective: 'published'` or `stega: false`, as this would mean Visual Editing and previewing draft content (as well as specific content releases) won't work.
-
-In other words, always do this:
-
-```tsx
-import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function CachedComponent({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
-  'use cache'
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
-}
-```
-
-Never do:
-
-```tsx
-import {sanityFetch} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function CachedComponent({slug}: {slug: string}) {
-  'use cache'
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({
-    query: pageQuery,
-    params: {slug},
-    perspective: 'published',
-    stega: false,
-  }) // oh no, perspective and stega options are hardcoded!
-}
-```
-
-If `sanityFetch` is called within a server action (boundary with `'use server'`) then you should never hardcode `perspective` or `stega` either, and also never take them as props to the server action function since server action inputs are considered untrusted and can be manipulated by the client and the underlying POST request.
-Resolve them in the `'use server'` boundary, and pass them as props to a `'use cache'` boundary that calls `sanityFetch`.
-In other words, always do this for server action functions:
-
-```tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function fetchMore({page, perspective, stega}: {page: string} & DynamicFetchOptions) {
-  'use cache'
-  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
-  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega})
-  return data
-}
-async function renderMore({page}: {page: string}) {
-  'use server'
-  const {perspective, stega} = await getDynamicFetchOptions()
-  const data = await fetchMore({page, perspective, stega})
-}
-```
-
-Never do:
-
-```tsx
-import {sanityFetch} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function fetchMore({page}: {page: string}) {
-  'use cache'
-  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
-  const {data} = await sanityFetch({
-    query: pagesQuery,
-    params: {page},
-    perspective: 'published',
-    stega: false,
-  }) // oh no, perspective and stega options are hardcoded!
-  return data
-}
-async function renderMore({page}: {page: string}) {
-  'use server'
-  const data = await fetchMore({page})
-}
-```
-
-```tsx
-import {getDynamicFetchOptions, sanityFetch} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function renderMore({page}: {page: string}) {
-  'use server'
-  const {perspective, stega} = await getDynamicFetchOptions()
-  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
-  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega}) // oh no, sanityFetch is called in a 'use server' boundary directly, this means it won't be cached
-}
-```
-
-If `sanityFetch` is called in a `route.ts` file, then you typically want to hardcode `stega: false` and only resolve `perspective`, as the route handler is unlikely to return a `Response` that will be rendered in the same DOM as a `<VisualEditing>` component and thus use the stega encoded strings to render overlays. Stega encoding is at best going to be ignored and bloat the payload size unnecessarily, and at worst can cause errors and unexpected behavior.
-
-#### `sanityFetchMetadata`
-
-For fetching data in `generateMetadata`, `generateSitemaps`, `generateViewport`, `generateImageMetadata` functions and `icon.tsx`, `apple-icon.tsx`, `manifest.ts`, `opengraph-image.tsx`, `twitter-image.tsx`, `robots.ts`, `sitemap.ts` files.
-
-It's used the same way as `sanityFetch`, but without the ability to set `stega: true` as `sanityFetchMetadata` is designed to be used in contexts where stega encoding is never needed and should always be `false` and without the requirement of setting `'use cache'` at the callsite as the `sanityFetchMetadata` boundary itself already has it.
-
-Presentation Tool supports opening an app in a new preview window, in addition to its preview iframe. To ensure that the correct content release is previewed when checking metadata like `<title>` and such it's necessary to resolve `perspective`, as with `sanityFetch`.
-
-This means you should always do:
-
-```ts
-import {getDynamicFetchOptions, sanityFetchMetadata} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-export async function generateMetadata({params}: PageProps<'/[slug]'>) {
-  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetchMetadata({query: pageQuery, params: {slug}, perspective})
-}
-```
-
-Never do:
-
-```ts
-import {sanityFetchMetadata} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-export async function generateMetadata({params}: PageProps<'/[slug]'>) {
-  'use cache'
-  const {slug} = await params
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetchMetadata({
-    query: pageQuery,
-    params: {slug},
-    perspective: 'published', // oh no, perspective is hardcoded and perspective switching won't work
-  })
-}
-```
-
-#### `getDynamicFetchOptions`
-
-Since `sanityFetch` is designed to be called inside a `'use cache'` boundary, we need to resolve `perspective` and `stega` options outside of it and pass them as props.
-Resolving `perspective` calls a dynamic API, `cookies()`, so it needs to happen in a component that is wrapped in `<Suspense>` so that it does not block the rest of the page from streaming. Avoid calling `getDynamicFetchOptions` in the body of a `layout.tsx` or `page.tsx` that should remain part of the static shell. The exception is routes that intentionally use a sibling `loading.tsx` for fallback UI (see the dynamic segments section), in which case the page can await `getDynamicFetchOptions` directly because `loading.tsx` provides the streaming fallback.
-When Cache Components are enabled, `<Suspense>` boundaries determine what's part of the static shell that is prerendered during `next build` and what is streamed in at runtime. For fully prerendered routes, only render these `<Suspense>` boundaries in draft mode.
-
-Here's an example of what that looks like for a `<Footer>` component in a `layout.tsx` that fetches data:
-
-```tsx
-// src/app/(website)/layout.tsx
-
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-import {draftMode} from 'next/headers'
-import {Suspense} from 'react'
-
-export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
-  const {isEnabled: isDraftMode} = await draftMode()
-  return (
-    <>
-      {children}
-      {isDraftMode ? (
-        <Suspense fallback={<FooterFallback />}>
-          <DynamicFooter />
-        </Suspense>
-      ) : (
-        <Footer perspective="published" stega={false} />
-      )}
-    </>
-  )
-}
-async function DynamicFooter() {
-  const {perspective, stega} = await getDynamicFetchOptions()
-  return <Footer perspective={perspective} stega={stega} />
-}
-async function Footer({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const footerQuery = defineQuery(`*[_type == "footer"][0]`)
-  const {data} = await sanityFetch({query: footerQuery, perspective, stega})
-  return <footer>{/* use `data` to render stuff */}</footer>
-}
-function FooterFallback() {
-  return (
-    <footer>
-      <p>Loading footer...</p>
-    </footer>
-  )
-}
-```
-
-In this example the `<Footer perspective="published" stega={false} />` is able to be part of the static shell during prerender, so the whole layout is properly cached and only revalidated whenever content used by the `sanityFetch` call in `Footer` changes. While also ensuring that while in draft mode the page does not block on the `sanityFetch` call and the layout can render immediately, using its static shell while the `<DynamicFooter>` is streaming in at the `<Suspense>` boundary. If it's fast enough then `<FooterFallback>` will never show.
-
-#### `sanityFetchStaticParams`
-
-When fetching data in a `generateStaticParams` function, then we never want `stega` since the data is used to generate route params, and we also know that this function is only called at `next build` time so there is no point in trying to resolve a `perspective` from `cookies`, as it's never run at request time where there might be cookies.
-
-In other words, never call `sanityFetch` in a `generateStaticParams` function, always use `sanityFetchStaticParams`. Never call `sanityFetchStaticParams` outside of a `generateStaticParams` function.
+| Helper                     | Used in                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `sanityFetch`              | `'use cache'` components rendered from `page.tsx` / `layout.tsx`     |
+| `sanityFetchMetadata`      | `generateMetadata`, `generateViewport`, `sitemap.ts`, `robots.ts`, `opengraph-image.tsx`, etc. |
+| `sanityFetchStaticParams`  | `generateStaticParams` only                                          |
+| `getDynamicFetchOptions`   | Resolving `perspective`/`stega` outside any `'use cache'` boundary   |
+| `SanityLive`               | Rendered once in a root layout                                       |
 
 ---
 
 ## 4. Render `<SanityLive>` in a root layout
 
-The `<SanityLive>` component exported from `defineLive` should be in the root layout.
-Usually that is `src/app/layout.tsx`, and is also where `<VisualEditing />` from `next-sanity/visual-editing` is rendered. Regardless of how the Next.js app might be using Route Groups and nested layouts and pages, the `<SanityLive>` and `<VisualEditing>` components should be in a `layout.tsx`, not a `page.tsx`. At any point in time both components should at most be rendered once, rendering the same component multiple times is undefined behavior and can cause unexpected problems.
+`<SanityLive>` and `<VisualEditing>` both belong in a `layout.tsx`, never a `page.tsx`. Both must be rendered at most once across the whole tree — duplicate renders are undefined behavior.
 
 ```tsx
 // src/app/layout.tsx
@@ -373,370 +125,40 @@ export default async function RootLayout({children}: LayoutProps<'/'>) {
 }
 ```
 
-### Dealing with embedded Sanity Studio
+### With an embedded Sanity Studio
 
-If there's a route that renders an embedded Sanity Studio, using `NextStudio` from `next-sanity/studio`, then the `<SanityLive>` needs to be in a layout that won't be used by the embedded studio, using [route groups](https://nextjs.org/docs/app/api-reference/file-conventions/route-groups).
-For example, if `NextStudio` is used on `app/studio/[[...index]]/page.tsx`, then the `<SanityLive>` needs to be in `src/app/(website)/layout.tsx` and the rest of the app should be in `src/app/(website)`.
+If a route mounts `NextStudio` from `next-sanity/studio` (e.g. `app/studio/[[...index]]/page.tsx`), `<SanityLive>` must live in a layout the embedded studio doesn't share. Use [route groups](https://nextjs.org/docs/app/api-reference/file-conventions/route-groups): put `<SanityLive>` in `src/app/(website)/layout.tsx` and keep the rest of the app under `src/app/(website)`.
 
 ---
 
-## 5. The Three-Layer Component Pattern
+## 5. Apply the three-layer pattern to pages and layouts
 
-This is the core architecture for every route that can be fully statically prerendered and cached.
+Every route that should be statically prerendered uses the same shape:
 
-### Structure
-
-```
-Page/Layout (Layer 1)
+```text
+Page/Layout (Layer 1: draftMode branch)
   ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
   └── draft mode → <Suspense fallback={...}>
-                      <DynamicX params={params} />  (Layer 2)
-                        └── <CachedX params={await params} perspective={p} stega={s} />  (Layer 3)
+                      <DynamicX params={params} />  (Layer 2: awaits dynamic APIs)
+                        └── <CachedX perspective={p} stega={s} />  (Layer 3: 'use cache')
 ```
 
-### Example with a `[slug]/page.tsx` route
+Pick the right reference for the file you're editing:
 
-The layer examples below showcase how to handle params on a `/[slug]/page.tsx` route, which requires a `generateStaticParams` function like the one below:
-
-```tsx
-// src/app/[slug]/page.tsx
-import {sanityFetchStaticParams} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-export async function generateStaticParams() {
-  const pageSlugsQuery = defineQuery(
-    `*[_type == "page" && defined(slug.current)]{"slug": slug.current}`,
-  )
-  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
-  return data
-}
-```
-
-On routes like `/layout.tsx` or `/page.tsx` you can omit the `params` handling.
-
-### Layer 1: Page Component
-
-Calls `draftMode()` and branches:
-
-```tsx
-// src/app/[slug]/page.tsx (continued)
-import {draftMode} from 'next/headers'
-import {Suspense} from 'react'
-
-export default async function Page({params}: PageProps<'/[slug]'>) {
-  const {isEnabled: isDraftMode} = await draftMode()
-  if (isDraftMode) {
-    return (
-      <Suspense
-        // optional, but highly recommended, a good fallback skeleton should not cause layout shift when `<Suspense>` transitions from showing `fallback` to `children`
-        fallback={<PageFallback />}
-      >
-        <DynamicPage
-          // do not await `params` here, it needs to be awaited in `<DynamicPage>` for the Suspense boundary to work
-          params={params}
-        />
-      </Suspense>
-    )
-  }
-  const {slug} = await params
-  return <CachedPage slug={slug} perspective="published" stega={false} />
-}
-```
-
-- `Page` should not have a `'use cache'` directive. `draftMode()` itself is allowed inside `'use cache'`, but `Page` also awaits `params` and (in routes that need it, such as Case 1 in section 7) calls `getDynamicFetchOptions()`, which calls `cookies()` whenever `draftMode().isEnabled`. `cookies()`, `headers()`, `await params`, and `await searchParams` are not allowed inside `'use cache'` (even when draft mode is active and the cache layer is bypassed). It's enough for `<CachedPage>` (Layer 3) to carry `'use cache'` for `Page` to also be prerendered as part of the static shell.
-- Requires `generateStaticParams` if `params` is used as input to `sanityFetch`
-- **Not in draft mode**: no `<Suspense>` boundary, maximizes static shell
-- **In draft mode**: render `<DynamicPage />` in a `<Suspense>` boundary, preferably with a good fallback skeleton as it'll suspend twice:
-  1. first suspend when `<DynamicPage>` is rendered as it will `await getDynamicFetchOptions()`
-  2. second suspend when `<CachedPage />` is rendered as it will `await sanityFetch()` using the `perspective` and `stega` options resolved by `<DynamicPage>`
-
-#### `searchParams` and other dynamic APIs
-
-If you need to use `searchParams` or other dynamic APIs (or `params` without providing `generateStaticParams` or a `loading.tsx` for the route, see [the guide for deciding whether to use `loading.tsx` or `<Suspense>`](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense)) as input to `sanityFetch`, then you should always render the `<Suspense>` tree and no longer branch on `draftMode`:
-
-```tsx
-// src/app/[slug]/page.tsx (continued)
-import {Suspense} from 'react'
-
-// Do not export an async function here, to avoid accidentally blocking render while awaiting a dynamic API
-export default function Page({params}: PageProps<'/[slug]'>) {
-  return (
-    <Suspense
-      // not optional since we no longer branch on `draftMode`, not providing a skeleton means Suspense will render `null`, causing massive layout shift that users hate
-      fallback={<PageFallback />}
-    >
-      <DynamicPage
-        // do not await `params` here, it needs to be awaited in `<DynamicPage>` for the Suspense boundary to work
-        params={params}
-      />
-    </Suspense>
-  )
-}
-```
-
-### Layer 2: Dynamic Component
-
-Since `<CachedPage>` has `'use cache'` it's not allowed to call `cookies()`, `headers()`, `await props.params`, or `await props.searchParams` — these must be resolved in `<DynamicPage>` and passed as plain props. `draftMode()` is the one exception and can be read directly inside `<CachedPage>`, but in this pattern it's not needed there because `perspective` and `stega` already encode the draft state via `getDynamicFetchOptions()`.
-
-```tsx
-// src/app/[slug]/page.tsx (continued)
-import {getDynamicFetchOptions} from '@/sanity/lib/live'
-
-async function DynamicPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
-  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
-
-  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
-}
-```
-
-### Layer 3: Cached Component
-
-Has `'use cache'` and only receives plain, serializable props:
-
-```tsx
-// src/app/[slug]/page.tsx (continued)
-import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-async function CachedPage({
-  slug,
-  perspective,
-  stega,
-}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({
-    query: pageQuery,
-    params: {slug},
-    perspective,
-    stega,
-  })
-  return <article>{/* use `data` to render stuff */}</article>
-}
-```
+- **`page.tsx`** with static or `generateStaticParams`-backed params → [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`page.tsx`** that uses `searchParams` or other dynamic APIs → the `searchParams` variant in [reference/three-layer-pattern.md](reference/three-layer-pattern.md).
+- **`layout.tsx`** that fetches its own data → [reference/layouts.md](reference/layouts.md).
+- **Dynamic `[slug]` route** that needs the `loading.tsx` + partial `generateStaticParams` optimization, or a layout that needs non-blocking `params` → [reference/dynamic-segments.md](reference/dynamic-segments.md).
 
 ---
 
-## 6. Non-blocking data fetching for `layout.tsx` in draft mode
+## Anti-patterns to grep for
 
-When using `sanityFetch` in a `layout.tsx` file then it's important to keep these constraints in mind when implementing the 3-layer pattern:
+When auditing an app, search for these and refactor:
 
-- The top-level component in `layout.tsx` should not `await` any dynamic APIs or perform data fetching, it can reduce the static shell, and it slows down streaming in draft mode.
-- Data fetching, and [dynamic API calls, should be pushed closer to where it's used](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down).
-- Shared data fetching can be extracted to a reused async `use cache` boundary function to reduce the footprint of multiple components that need the same data and to reduce latency in draft mode.
-
-In other words, do this:
-
-```tsx
-// src/app/(website)/layout.tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-import {draftMode} from 'next/headers'
-import {Suspense} from 'react'
-
-async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
-  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
-  return data
-}
-
-export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
-  const {isEnabled: isDraftMode} = await draftMode()
-  return (
-    <>
-      {isDraftMode ? (
-        <Suspense fallback={<NavbarFallback />}>
-          <DynamicNavbar />
-        </Suspense>
-      ) : (
-        <CachedNavbar perspective="published" stega={false} />
-      )}
-      {children}
-      {isDraftMode ? (
-        <Suspense>
-          <DynamicFooter />
-        </Suspense>
-      ) : (
-        <CachedFooter perspective="published" stega={false} />
-      )}
-    </>
-  )
-}
-
-async function DynamicNavbar() {
-  const {perspective, stega} = await getDynamicFetchOptions()
-  return <CachedNavbar perspective={perspective} stega={stega} />
-}
-async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const data = await fetchSettings({perspective, stega})
-  return <Navbar data={data} />
-}
-
-async function DynamicFooter() {
-  const {perspective, stega} = await getDynamicFetchOptions()
-  return <CachedFooter perspective={perspective} stega={stega} />
-}
-async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
-  'use cache'
-  const data = await fetchSettings({perspective, stega})
-  return <Footer data={data} />
-}
-```
-
-Never do this:
-
-```tsx
-// src/app/(website)/layout.tsx
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-import {draftMode} from 'next/headers'
-import type {ReactNode} from 'react'
-import {Suspense} from 'react'
-
-export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
-  const {isEnabled: isDraftMode} = await draftMode()
-  if (isDraftMode) {
-    return (
-      <Suspense>
-        <DynamicWebsiteLayout>{children}</DynamicWebsiteLayout>
-      </Suspense>
-    )
-  }
-  return (
-    <CachedWebsiteLayout perspective="published" stega={false}>
-      {children}
-    </CachedWebsiteLayout>
-  )
-}
-async function DynamicWebsiteLayout({children}: {children: ReactNode}) {
-  const {perspective, stega} = await getDynamicFetchOptions()
-  return (
-    <CachedWebsiteLayout perspective={perspective} stega={stega}>
-      {children}
-    </CachedWebsiteLayout>
-  )
-}
-async function CachedWebsiteLayout({
-  children,
-  perspective,
-  stega,
-}: {children: ReactNode} & DynamicFetchOptions) {
-  'use cache'
-  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
-  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
-
-  return (
-    <>
-      <Navbar data={data} />
-      {children}
-      <Footer data={data} />
-    </>
-  )
-}
-```
-
----
-
-## 7. High performance [`Dynamic Segments`](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes)
-
-It's always recommended that routes with dynamic segments make sure to implement `generateStaticParams`, even if it's just a subset of all pages. [Read more.](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components)
-Whether you use `loading.tsx` or `<Suspense>` to show fallback UI depends on the use case. [Read more.](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense)
-
-This section will guide you through 2 different implementations and their pros and cons.
-
-### Case 1: `page.tsx` prerendering 100 most recently updated pages with instant loading states
-
-A `generateStaticParams` queries only the 100 most recently updated pages, with fallback UI implemented in a `loading.tsx` so that the `page.tsx` itself does not need to use `<Suspense>`, and the same fallback UI is used in draft mode as well.
-This case can scale to thousands of pages, without slowing down your `next build` time to a grinding halt, and without compromising the UX in production:
-
-- prerendered pages load instantly.
-- pages not prerendered start rendering when hovering a `<Link>` (or scrolling the `<Link>` into view) so that on `click` it:
-  - if it prerendered in time it'll serve the new page instantly, no loading state.
-  - if it didn't prerender in time it'll instantly show the fallback UI, as the `loading.tsx` is prefetched from cache.
-
-Add a sibling `src/app/[slug]/loading.tsx` that renders the same fallback skeleton you would otherwise pass to `<Suspense>`.
-
-```tsx
-// src/app/[slug]/page.tsx
-import {
-  getDynamicFetchOptions,
-  sanityFetch,
-  sanityFetchStaticParams,
-  type DynamicFetchOptions,
-} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-
-export async function generateStaticParams() {
-  const pageSlugsQuery = defineQuery(
-    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
-  )
-  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
-  return data
-}
-
-// Since there is a sibling `loading.tsx` file, we don't need a `<Suspense>` wrapper and a `DynamicPage` intermediate component, we can await `params` and `getDynamicFetchOptions` directly in the `Page` component.
-export default async function Page({params}: PageProps<'/[slug]'>) {
-  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
-  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
-}
-async function CachedPage({
-  slug,
-  perspective,
-  stega,
-}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({
-    query: pageQuery,
-    params: {slug},
-    perspective,
-    stega,
-  })
-  return <article>{/* use `data` to render stuff */}</article>
-}
-```
-
-### Case 2: `layout.tsx` non-blocking data fetching using dynamic `params`
-
-A `layout.tsx` can't use `loading.tsx` to implement fallback UI, [as it's one level higher](https://nextjs.org/docs/app/getting-started/project-structure#component-hierarchy). And so a different pattern is needed in order to efficiently fetch data that uses dynamic `params` without blocking the `children` from streaming in.
-
-```tsx
-// src/app/(website)/[slug]/layout.tsx
-
-import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
-import {defineQuery} from 'next-sanity'
-import {Suspense} from 'react'
-
-export default function WebsiteLayout({children, params}: LayoutProps<'/[slug]'>) {
-  return (
-    <>
-      {children}
-      {/* The footer renders below the fold so it doesn't need a fallback */}
-      <Suspense>
-        <DynamicFooter
-          // Don't await `params`, pass the promise and await within the `<Suspense>` boundary so `children` isn't blocked and can stream in parallel
-          params={params}
-        />
-      </Suspense>
-    </>
-  )
-}
-async function DynamicFooter({params}: Pick<LayoutProps<'/[slug]'>, 'params'>) {
-  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
-  return <Footer slug={slug} perspective={perspective} stega={stega} />
-}
-async function Footer({
-  slug,
-  perspective,
-  stega,
-}: Awaited<LayoutProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  'use cache'
-  const footerQuery = defineQuery(`*[_type == "footer" && slug.current == $slug][0]`)
-  const {data} = await sanityFetch({query: footerQuery, params: {slug}, perspective, stega})
-  return <footer>{/* use `data` to render stuff */}</footer>
-}
-```
-
----
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → use the three-layer pattern, source `perspective`/`stega` via `getDynamicFetchOptions`.
+- `sanityFetch(` directly inside a function whose body begins with `'use server'` → split into a separate `'use cache'` helper.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move those dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.
+- More than one `<SanityLive>` or `<VisualEditing>` rendered in the tree → consolidate to a single render in the right layout.

--- a/skills/sanity-live-cache-components/SKILL.md
+++ b/skills/sanity-live-cache-components/SKILL.md
@@ -13,12 +13,13 @@ This skill assumes familiarity with the `next-cache-components` skill — it cov
 
 ## Prerequisites
 
-- Next.js 16.2+ (`pnpm view next version` or `npm view next version` to check).
+- Next.js 16.2+ installed in the project (check `package.json` or run `pnpm list next` / `npm ls next` — don't use `pnpm view next version`, that reports the registry's latest, not what's installed).
 - `AGENTS.md` exists, or [follow the guide](https://nextjs.org/docs/app/guides/ai-agents#existing-projects).
 - These environment variables are set:
   - `NEXT_PUBLIC_SANITY_PROJECT_ID`
   - `NEXT_PUBLIC_SANITY_DATASET`
   - `SANITY_API_READ_TOKEN`
+- Embedded Sanity Studio configuration (`sanity.config.ts`, `sanity.cli.ts`, anything under `sanity/`) needs no changes — this skill only touches the Next.js app surface.
 
 ## Reference files
 
@@ -105,6 +106,9 @@ The helpers exported from `live.ts`:
 
 `<SanityLive>` and `<VisualEditing>` both belong in a `layout.tsx`, never a `page.tsx`. Both must be rendered at most once across the whole tree — duplicate renders are undefined behavior.
 
+- `includeDrafts` is **required** when `defineLive` is configured with `strict: true` (the recommended setup). TypeScript will surface the error if it's missing; pass `includeDrafts={isDraftMode}` so live revalidation includes drafts only in draft mode.
+- Preserve any existing optional callback props on `<SanityLive>` when migrating: `onError`, `onWelcome`, `onReconnect`. They are commonly wired to a toast/notification helper and silently dropping them regresses UX.
+
 ```tsx
 // src/app/layout.tsx
 import {SanityLive} from '@/sanity/lib/live'
@@ -142,6 +146,8 @@ Page/Layout (Layer 1: draftMode branch)
                       <DynamicX params={params} />  (Layer 2: awaits dynamic APIs)
                         └── <CachedX perspective={p} stega={s} />  (Layer 3: 'use cache')
 ```
+
+**Critical rule**: Only Layer 3 carries `'use cache'`. The top-level `Page` / `Layout` must **not** have `'use cache'` — it awaits `params`, `searchParams`, or `cookies()` (via `getDynamicFetchOptions`), and those dynamic APIs are forbidden inside `'use cache'`. Layer 3 carrying `'use cache'` is enough for the whole route to prerender into the static shell. Adding `'use cache'` to the top-level function is the most common failure mode — TypeScript and the runtime will both complain.
 
 Pick the right reference for the file you're editing:
 

--- a/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -1,0 +1,103 @@
+# High-performance dynamic segments
+
+[Dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes) should always implement `generateStaticParams`, even if only a subset of pages — see [the Cache Components note on dynamic routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components). Whether to use `loading.tsx` or `<Suspense>` for fallback UI depends on the use case — see [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense).
+
+## Contents
+
+- [Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`](#case-1-pagetsx-with-loadingtsx--partial-generatestaticparams)
+- [Case 2: `layout.tsx` with non-blocking dynamic `params`](#case-2-layouttsx-with-non-blocking-dynamic-params)
+
+## Case 1: `page.tsx` with `loading.tsx` + partial `generateStaticParams`
+
+`generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
+
+This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
+
+- Prerendered pages load instantly.
+- Pages not prerendered start rendering on `<Link>` hover (or when scrolled into view), so on click:
+  - If prerendering finished in time → serves instantly, no loading state.
+  - If not → instantly shows the cached `loading.tsx` fallback.
+
+Add a sibling `src/app/[slug]/loading.tsx` that renders the same skeleton you would otherwise pass to `<Suspense>`.
+
+```tsx
+// src/app/[slug]/page.tsx
+import {
+  getDynamicFetchOptions,
+  sanityFetch,
+  sanityFetchStaticParams,
+  type DynamicFetchOptions,
+} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+
+// With sibling `loading.tsx`, skip the `<Suspense>` + `DynamicPage` indirection: await `params`
+// and `getDynamicFetchOptions` directly inside `Page`.
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## Case 2: `layout.tsx` with non-blocking dynamic `params`
+
+A `layout.tsx` can't use `loading.tsx` for fallback UI — [it's one level higher in the hierarchy](https://nextjs.org/docs/app/getting-started/project-structure#component-hierarchy). To fetch data that depends on dynamic `params` without blocking `children` from streaming, pass the unawaited `params` promise into a `<Suspense>` boundary and await it inside.
+
+```tsx
+// src/app/(website)/[slug]/layout.tsx
+
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {Suspense} from 'react'
+
+export default function WebsiteLayout({children, params}: LayoutProps<'/[slug]'>) {
+  return (
+    <>
+      {children}
+      {/* The footer renders below the fold, no fallback needed */}
+      <Suspense>
+        <DynamicFooter
+          // Don't await `params` here — pass the promise and await inside Suspense so `children` streams in parallel
+          params={params}
+        />
+      </Suspense>
+    </>
+  )
+}
+async function DynamicFooter({params}: Pick<LayoutProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  return <Footer slug={slug} perspective={perspective} stega={stega} />
+}
+async function Footer({
+  slug,
+  perspective,
+  stega,
+}: Awaited<LayoutProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: footerQuery, params: {slug}, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+```

--- a/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -18,7 +18,18 @@ This scales to thousands of pages without ballooning `next build` and without co
   - If prerendering finished in time → serves instantly, no loading state.
   - If not → instantly shows the cached `loading.tsx` fallback.
 
-Add a sibling `src/app/[slug]/loading.tsx` that renders the same skeleton you would otherwise pass to `<Suspense>`.
+Add a sibling `src/app/[slug]/loading.tsx` that renders the same skeleton you would otherwise pass to `<Suspense>`. Keep it cheap and free of layout shift:
+
+```tsx
+// src/app/[slug]/loading.tsx
+export default function Loading() {
+  return (
+    <article aria-busy>
+      <p>Loading…</p>
+    </article>
+  )
+}
+```
 
 ```tsx
 // src/app/[slug]/page.tsx

--- a/skills/sanity-live-cache-components/reference/layouts.md
+++ b/skills/sanity-live-cache-components/reference/layouts.md
@@ -1,0 +1,163 @@
+# Non-blocking layout patterns
+
+When `sanityFetch` runs inside a `layout.tsx`, the goal is to keep `children` streaming and keep the static shell as large as possible.
+
+## Contents
+
+- [Rules](#rules)
+- [Pattern: shared `'use cache'` helper per draft/published branch](#pattern-shared-use-cache-helper-per-draftpublished-branch)
+- [Anti-pattern: wrapping `children` in a single cached layout](#anti-pattern-wrapping-children-in-a-single-cached-layout)
+- [Simpler example: a single `<Footer>`](#simpler-example-a-single-footer)
+
+## Rules
+
+- The top-level `layout.tsx` component must not `await` dynamic APIs or fetch data. Either reduces the static shell or slows draft-mode streaming.
+- Push [dynamic API calls](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down) down to the leaf that needs them.
+- Extract shared data fetching into a reusable async `'use cache'` helper so two components that need the same data don't both wait independently.
+
+## Pattern: shared `'use cache'` helper per draft/published branch
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+async function fetchSettings({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+  return data
+}
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {isDraftMode ? (
+        <Suspense fallback={<NavbarFallback />}>
+          <DynamicNavbar />
+        </Suspense>
+      ) : (
+        <CachedNavbar perspective="published" stega={false} />
+      )}
+      {children}
+      {isDraftMode ? (
+        <Suspense>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <CachedFooter perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+
+async function DynamicNavbar() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedNavbar perspective={perspective} stega={stega} />
+}
+async function CachedNavbar({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Navbar data={data} />
+}
+
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <CachedFooter perspective={perspective} stega={stega} />
+}
+async function CachedFooter({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const data = await fetchSettings({perspective, stega})
+  return <Footer data={data} />
+}
+```
+
+## Anti-pattern: wrapping `children` in a single cached layout
+
+This blocks `children` on the layout's data fetch and prevents the page itself from streaming in independently.
+
+```tsx
+// src/app/(website)/layout.tsx
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense>
+        <DynamicWebsiteLayout>{children}</DynamicWebsiteLayout>
+      </Suspense>
+    )
+  }
+  return (
+    <CachedWebsiteLayout perspective="published" stega={false}>
+      {children}
+    </CachedWebsiteLayout>
+  )
+}
+async function CachedWebsiteLayout({
+  children,
+  perspective,
+  stega,
+}: {children: ReactNode} & DynamicFetchOptions) {
+  'use cache'
+  const settingsQuery = defineQuery(`*[_type == "settings"][0]`)
+  const {data} = await sanityFetch({query: settingsQuery, perspective, stega})
+
+  return (
+    <>
+      <Navbar data={data} />
+      {children}
+      <Footer data={data} />
+    </>
+  )
+}
+```
+
+## Simpler example: a single `<Footer>`
+
+Useful as a sanity check when adapting the pattern to a layout with only one data-driven section:
+
+```tsx
+// src/app/(website)/layout.tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function WebsiteLayout({children}: LayoutProps<'/'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  return (
+    <>
+      {children}
+      {isDraftMode ? (
+        <Suspense fallback={<FooterFallback />}>
+          <DynamicFooter />
+        </Suspense>
+      ) : (
+        <Footer perspective="published" stega={false} />
+      )}
+    </>
+  )
+}
+async function DynamicFooter() {
+  const {perspective, stega} = await getDynamicFetchOptions()
+  return <Footer perspective={perspective} stega={stega} />
+}
+async function Footer({perspective, stega}: DynamicFetchOptions) {
+  'use cache'
+  const footerQuery = defineQuery(`*[_type == "footer"][0]`)
+  const {data} = await sanityFetch({query: footerQuery, perspective, stega})
+  return <footer>{/* use `data` to render stuff */}</footer>
+}
+function FooterFallback() {
+  return (
+    <footer>
+      <p>Loading footer...</p>
+    </footer>
+  )
+}
+```
+
+The non-draft `<Footer perspective="published" stega={false} />` is part of the static shell, so the whole layout is cached and revalidates only when content used by `sanityFetch` changes. In draft mode the layout still renders immediately from its static shell while `<DynamicFooter>` streams in.

--- a/skills/sanity-live-cache-components/reference/layouts.md
+++ b/skills/sanity-live-cache-components/reference/layouts.md
@@ -11,7 +11,7 @@ When `sanityFetch` runs inside a `layout.tsx`, the goal is to keep `children` st
 
 ## Rules
 
-- The top-level `layout.tsx` component must not `await` dynamic APIs or fetch data. Either reduces the static shell or slows draft-mode streaming.
+- The top-level `layout.tsx` component must not `await` dynamic APIs (other than `draftMode()`) or fetch data. `draftMode()` is the lone exception because Next.js bypasses caching when it's enabled and a `draftMode()`-only top-level component still prerenders into the static shell. Anything else (`cookies()`, `headers()`, `await params`, `await searchParams`, `sanityFetch`) reduces the static shell or slows draft-mode streaming.
 - Push [dynamic API calls](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down) down to the leaf that needs them.
 - Extract shared data fetching into a reusable async `'use cache'` helper so two components that need the same data don't both wait independently.
 

--- a/skills/sanity-live-cache-components/reference/live-helpers.md
+++ b/skills/sanity-live-cache-components/reference/live-helpers.md
@@ -1,0 +1,214 @@
+# Live helpers: `client.ts` and `live.ts`
+
+## Contents
+
+- [`client.ts`](#clientts)
+- [`live.ts`](#livets)
+- [`sanityFetch`](#sanityfetch)
+- [`sanityFetchMetadata`](#sanityfetchmetadata)
+- [`getDynamicFetchOptions`](#getdynamicfetchoptions)
+- [`sanityFetchStaticParams`](#sanityfetchstaticparams)
+- [Anti-patterns to grep for](#anti-patterns-to-grep-for)
+
+## `client.ts`
+
+Projects typically have a `src/sanity/lib/client.ts` that exports a `createClient` instance:
+
+```ts
+// src/sanity/lib/client.ts
+import {createClient} from 'next-sanity'
+
+export const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  useCdn: true,
+  apiVersion: '2026-05-19',
+  perspective: 'published',
+  stega: {studioUrl: process.env.NEXT_PUBLIC_SANITY_STUDIO_URL || 'http://localhost:3333'},
+})
+```
+
+- Use a modern `apiVersion` (e.g. today's date as a hardcoded string).
+- `stega.studioUrl` enables stega encoding. It can be a relative string when an embedded Studio is mounted via `NextStudio` from `next-sanity/studio`, otherwise an absolute URL (typically env-driven).
+- If `client.ts` already exists, **append** missing options rather than overwriting. Changing `apiVersion` or removing existing `stega.*` options can break callers.
+- Never remove an existing `token` from `createClient`. Private datasets require a client token even for published-content fetches.
+
+## `live.ts`
+
+Create `src/sanity/lib/live.ts` alongside `client.ts`. If it already exists, append only what's missing.
+
+```ts
+// src/sanity/lib/live.ts
+import {type QueryParams} from 'next-sanity'
+import {defineLive, resolvePerspectiveFromCookies, type LivePerspective} from 'next-sanity/live'
+import {cookies, draftMode} from 'next/headers'
+import {client} from './client'
+
+const token = process.env.SANITY_API_READ_TOKEN
+if (!token) {
+  throw new Error('Missing SANITY_API_READ_TOKEN')
+}
+
+export const {SanityLive, sanityFetch} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+  strict: true,
+})
+
+export interface DynamicFetchOptions {
+  perspective: LivePerspective
+  stega: boolean
+}
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (!isDraftMode) {
+    return {perspective: 'published', stega: false}
+  }
+
+  const jar = await cookies()
+  const perspective = await resolvePerspectiveFromCookies({cookies: jar})
+  return {perspective: perspective ?? 'drafts', stega: true}
+}
+
+// For usage within `generateStaticParams`
+export async function sanityFetchStaticParams<const QueryString extends string>({
+  query,
+  params = {},
+}: {
+  query: QueryString
+  params?: QueryParams
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective: 'published', stega: false})
+  return {data}
+}
+
+// For usage within `generateMetadata` and `generateViewport`
+export async function sanityFetchMetadata<const QueryString extends string>({
+  query,
+  params = {},
+  perspective,
+}: {
+  query: QueryString
+  params?: QueryParams
+  perspective: LivePerspective
+}) {
+  'use cache'
+  const {data} = await sanityFetch({query, params, perspective, stega: false})
+  return {data}
+}
+```
+
+## `sanityFetch`
+
+For fetching data in React Server Components that have a `'use cache'` directive and are rendered (directly or transitively) from a `page.tsx` or `layout.tsx`.
+
+- `perspective` switches between published, drafts, and specific Sanity Content Releases.
+- `stega: true` (combined with `stega.studioUrl` in `createClient` and `<VisualEditing>` in the root layout) renders click-to-edit overlays.
+- `getDynamicFetchOptions` resolves `perspective` from the `sanity-preview-perspective` cookie, which `<VisualEditing>` manages when the app is rendered inside Presentation Tool's preview iframe.
+
+The async function that calls `sanityFetch` must carry `'use cache'` or `'use cache: remote'`, and must take `perspective` and `stega` as props. Never hardcode them.
+
+Pattern:
+
+```tsx
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedComponent({slug, perspective, stega}: {slug: string} & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({query: pageQuery, params: {slug}, perspective, stega})
+}
+```
+
+Anti-pattern (hardcoded options break Visual Editing and content-release previewing):
+
+```tsx
+async function CachedComponent({slug}: {slug: string}) {
+  'use cache'
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective: 'published', // hardcoded
+    stega: false, // hardcoded
+  })
+}
+```
+
+### `sanityFetch` inside server actions
+
+`'use server'` boundaries cannot accept `perspective`/`stega` as props (server action inputs are untrusted). Resolve them inside the `'use server'` function and forward them to a separate `'use cache'` boundary:
+
+```tsx
+import {getDynamicFetchOptions, sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function fetchMore({page, perspective, stega}: {page: string} & DynamicFetchOptions) {
+  'use cache'
+  const pagesQuery = defineQuery(`*[_type == "page"][0...$page]`)
+  const {data} = await sanityFetch({query: pagesQuery, params: {page}, perspective, stega})
+  return data
+}
+async function renderMore({page}: {page: string}) {
+  'use server'
+  const {perspective, stega} = await getDynamicFetchOptions()
+  const data = await fetchMore({page, perspective, stega})
+}
+```
+
+Anti-patterns:
+
+- Hardcoding `perspective`/`stega` in the `'use cache'` helper.
+- Calling `sanityFetch` directly inside `'use server'` — it bypasses caching entirely.
+
+### `sanityFetch` inside `route.ts`
+
+Hardcode `stega: false` and resolve only `perspective`. Route handlers don't render a DOM next to `<VisualEditing>`, so stega encoding only inflates the payload (and can cause downstream errors).
+
+## `sanityFetchMetadata`
+
+For fetching data inside `generateMetadata`, `generateSitemaps`, `generateViewport`, `generateImageMetadata`, and the file-based metadata routes (`icon.tsx`, `apple-icon.tsx`, `manifest.ts`, `opengraph-image.tsx`, `twitter-image.tsx`, `robots.ts`, `sitemap.ts`).
+
+It's `sanityFetch` without `stega` (never wanted in these contexts) and without requiring `'use cache'` at the callsite — the helper already provides it.
+
+Presentation Tool can open an app in a standalone preview window, so the correct content release must still be reflected in `<title>` and friends. Always resolve `perspective`:
+
+```ts
+import {getDynamicFetchOptions, sanityFetchMetadata} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateMetadata({params}: PageProps<'/[slug]'>) {
+  const [{slug}, {perspective}] = await Promise.all([params, getDynamicFetchOptions()])
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetchMetadata({query: pageQuery, params: {slug}, perspective})
+}
+```
+
+Anti-pattern: hardcoding `perspective: 'published'` — content-release previewing won't work.
+
+## `getDynamicFetchOptions`
+
+Resolves `perspective` and `stega` outside the `'use cache'` boundary so they can be passed in as plain props. Calls `cookies()`, which is a dynamic API, so the call must live inside a `<Suspense>` boundary (or a route with a sibling `loading.tsx`) so it doesn't block the static shell from streaming.
+
+Avoid calling `getDynamicFetchOptions` in the top-level body of a `layout.tsx` or `page.tsx` that should remain part of the static shell. The exception is routes that intentionally use a sibling `loading.tsx` for fallback UI (see [dynamic-segments.md](dynamic-segments.md)) — there the page can await `getDynamicFetchOptions` directly because `loading.tsx` provides the streaming fallback.
+
+When Cache Components are enabled, `<Suspense>` boundaries determine the static shell. For fully prerendered routes, render the Suspense tree only when in draft mode — see [three-layer-pattern.md](three-layer-pattern.md).
+
+## `sanityFetchStaticParams`
+
+Used inside `generateStaticParams`. `stega` is never wanted (the data feeds route params), and `perspective` cookies aren't available at build time anyway, so both are hardcoded.
+
+- Never call `sanityFetch` inside `generateStaticParams` — always use `sanityFetchStaticParams`.
+- Never call `sanityFetchStaticParams` outside `generateStaticParams`.
+
+## Anti-patterns to grep for
+
+When migrating an existing app, these are the strings to search for and refactor:
+
+- `perspective: 'published'` and `stega: false` hardcoded together in a `sanityFetch` call → replace with `perspective` and `stega` props sourced from `getDynamicFetchOptions` via the three-layer pattern.
+- `sanityFetch(` directly inside a function whose body starts with `'use server'` → split into a separate `'use cache'` helper and forward `perspective`/`stega` as props.
+- `sanityFetch(` inside `generateStaticParams` → swap for `sanityFetchStaticParams`.
+- `sanityFetch(` inside `generateMetadata` / `generateViewport` / `sitemap.ts` / `robots.ts` / `opengraph-image.tsx` etc. → swap for `sanityFetchMetadata` and resolve `perspective` via `getDynamicFetchOptions`.
+- `await draftMode()` immediately followed by `await getDynamicFetchOptions()` at the top of a `page.tsx` or `layout.tsx` without a sibling `loading.tsx` → move the dynamic-API calls into a child component wrapped in `<Suspense>` so the static shell can prerender.

--- a/skills/sanity-live-cache-components/reference/live-helpers.md
+++ b/skills/sanity-live-cache-components/reference/live-helpers.md
@@ -12,7 +12,9 @@
 
 ## `client.ts`
 
-Projects typically have a `src/sanity/lib/client.ts` that exports a `createClient` instance:
+Projects typically have a `src/sanity/lib/client.ts` that exports a `createClient` instance.
+
+**If no `client.ts` exists yet**, use this shape as a starting point:
 
 ```ts
 // src/sanity/lib/client.ts
@@ -28,14 +30,18 @@ export const client = createClient({
 })
 ```
 
+**If `client.ts` already exists**, leave its structure alone. Templates often centralize env-var reads in a separate `sanity/lib/api.ts` with an `assertValue` helper — keep that. Append only what's missing.
+
 - Use a modern `apiVersion` (e.g. today's date as a hardcoded string).
 - `stega.studioUrl` enables stega encoding. It can be a relative string when an embedded Studio is mounted via `NextStudio` from `next-sanity/studio`, otherwise an absolute URL (typically env-driven).
-- If `client.ts` already exists, **append** missing options rather than overwriting. Changing `apiVersion` or removing existing `stega.*` options can break callers.
+- Changing `apiVersion` or removing existing `stega.*` options can break callers.
 - Never remove an existing `token` from `createClient`. Private datasets require a client token even for published-content fetches.
 
 ## `live.ts`
 
 Create `src/sanity/lib/live.ts` alongside `client.ts`. If it already exists, append only what's missing.
+
+`SANITY_API_READ_TOKEN` must never reach the client bundle. If the project already keeps it in a dedicated server-only module (commonly `src/sanity/lib/token.ts` with `import 'server-only'` at the top), import the token from there instead of inlining the `process.env` read. The example below inlines it for brevity — swap in the existing module if there is one.
 
 ```ts
 // src/sanity/lib/live.ts

--- a/skills/sanity-live-cache-components/reference/three-layer-pattern.md
+++ b/skills/sanity-live-cache-components/reference/three-layer-pattern.md
@@ -1,0 +1,146 @@
+# Three-layer component pattern
+
+The core architecture for every route that can be fully statically prerendered and cached.
+
+## Contents
+
+- [Structure](#structure)
+- [`generateStaticParams` for dynamic routes](#generatestaticparams-for-dynamic-routes)
+- [Layer 1: Page component](#layer-1-page-component)
+- [Layer 2: Dynamic component](#layer-2-dynamic-component)
+- [Layer 3: Cached component](#layer-3-cached-component)
+- [`searchParams` and other dynamic APIs](#searchparams-and-other-dynamic-apis)
+
+## Structure
+
+```text
+Page/Layout (Layer 1)
+  ├── NOT draft mode → <CachedX perspective="published" stega={false} />  (no Suspense)
+  └── draft mode → <Suspense fallback={...}>
+                      <DynamicX params={params} />  (Layer 2)
+                        └── <CachedX params={await params} perspective={p} stega={s} />  (Layer 3)
+```
+
+## `generateStaticParams` for dynamic routes
+
+The examples below use `/[slug]/page.tsx`, which needs:
+
+```tsx
+// src/app/[slug]/page.tsx
+import {sanityFetchStaticParams} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+export async function generateStaticParams() {
+  const pageSlugsQuery = defineQuery(
+    `*[_type == "page" && defined(slug.current)]{"slug": slug.current}`,
+  )
+  const {data} = await sanityFetchStaticParams({query: pageSlugsQuery})
+  return data
+}
+```
+
+For `/layout.tsx` or `/page.tsx` (no params), skip the `params` handling.
+
+## Layer 1: Page component
+
+Calls `draftMode()` and branches:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {draftMode} from 'next/headers'
+import {Suspense} from 'react'
+
+export default async function Page({params}: PageProps<'/[slug]'>) {
+  const {isEnabled: isDraftMode} = await draftMode()
+  if (isDraftMode) {
+    return (
+      <Suspense fallback={<PageFallback />}>
+        <DynamicPage
+          // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+          params={params}
+        />
+      </Suspense>
+    )
+  }
+  const {slug} = await params
+  return <CachedPage slug={slug} perspective="published" stega={false} />
+}
+```
+
+Notes:
+
+- `Page` does **not** have a `'use cache'` directive. `draftMode()` is allowed inside `'use cache'`, but `Page` also `awaits` `params` (and may call `getDynamicFetchOptions()`, which reads `cookies()`), and those dynamic APIs are not allowed inside `'use cache'`. It's enough for `<CachedPage>` (Layer 3) to carry `'use cache'` for `Page` to be prerendered as part of the static shell.
+- Requires `generateStaticParams` if `params` is used as input to `sanityFetch`.
+- Not in draft mode → no `<Suspense>` boundary, maximizes the static shell.
+- In draft mode → `<DynamicPage />` inside `<Suspense>` will suspend twice:
+  1. when `<DynamicPage>` awaits `getDynamicFetchOptions()`
+  2. when `<CachedPage />` awaits `sanityFetch` with the resolved `perspective`/`stega`
+
+  A good fallback skeleton that doesn't cause layout shift is highly recommended.
+
+## Layer 2: Dynamic component
+
+Resolves `params`, `cookies()`, and `headers()` outside the cache boundary and passes plain props in:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {getDynamicFetchOptions} from '@/sanity/lib/live'
+
+async function DynamicPage({params}: Pick<PageProps<'/[slug]'>, 'params'>) {
+  const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+
+  return <CachedPage slug={slug} perspective={perspective} stega={stega} />
+}
+```
+
+`draftMode()` is the only dynamic API allowed inside `'use cache'`, but in this pattern it isn't needed in Layer 3 because `perspective` and `stega` already encode the draft state.
+
+## Layer 3: Cached component
+
+Has `'use cache'` and only receives plain, serializable props:
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {sanityFetch, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {defineQuery} from 'next-sanity'
+
+async function CachedPage({
+  slug,
+  perspective,
+  stega,
+}: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
+  'use cache'
+  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
+  const {data} = await sanityFetch({
+    query: pageQuery,
+    params: {slug},
+    perspective,
+    stega,
+  })
+  return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+## `searchParams` and other dynamic APIs
+
+If `searchParams` or other dynamic APIs are inputs to `sanityFetch` (or `params` is used without `generateStaticParams` or a `loading.tsx`), always render the `<Suspense>` tree and **stop branching on `draftMode`**. See [the streaming guide](https://nextjs.org/docs/app/guides/streaming#when-to-use-loadingjs-vs-suspense) for picking between `loading.tsx` and `<Suspense>`.
+
+```tsx
+// src/app/[slug]/page.tsx (continued)
+import {Suspense} from 'react'
+
+// Do not export an async function here, to avoid accidentally blocking render while awaiting a dynamic API
+export default function Page({params}: PageProps<'/[slug]'>) {
+  return (
+    <Suspense
+      // not optional — no draftMode branch means a missing skeleton causes massive layout shift
+      fallback={<PageFallback />}
+    >
+      <DynamicPage
+        // do not await `params` here, it needs to be awaited in `<DynamicPage>` so the Suspense boundary works
+        params={params}
+      />
+    </Suspense>
+  )
+}
+```


### PR DESCRIPTION
## Summary

Restructures the `sanity-live-cache-components` skill to follow Anthropic's published skill-authoring best practices. The single 742-line `SKILL.md` becomes a 164-line overview that progressively discloses detail through four sibling reference files.

### Why

The original skill predated the practices documented at https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices. Specifically:

- Body was 742 lines (Anthropic recommends under 500).
- Description was imperative ("Migrate next-sanity apps to…") — failed the third-person rule and didn't cover the greenfield use case.
- Opened with a "You are an expert in Next.js…" role-play preamble.
- Duplicated `'use cache'` mechanics already covered by the `next-cache-components` skill.
- Repeated do/don't code blocks inflated token cost without adding signal.

### What changed

**`skills/sanity-live-cache-components/SKILL.md`** (742 → 164 lines)
- New third-person description with explicit trigger keywords for both setup and migration paths (`sanityFetch`, `<SanityLive>`, Visual Editing, Presentation Tool, draft mode, three-layer pattern, hardcoded `perspective`/`stega`).
- Declarative purpose statement replaces the role-play preamble.
- One-line pointer to the `next-cache-components` skill instead of restating `'use cache'` rules.
- Navigation table near the top routes Claude to the right reference file.
- Linear 5-step setup doubles as the migration sequence, with a small "Migrating an existing Sanity Live setup" callout under step 1.
- Compact "Anti-patterns to grep for" checklist at the bottom for codebase audits.

**New `reference/` files** (each one-level-deep from SKILL.md, each with a ToC):
- `reference/live-helpers.md` — full `client.ts` / `live.ts`, plus per-helper guidance for `sanityFetch`, `sanityFetchMetadata`, `sanityFetchStaticParams`, `getDynamicFetchOptions`.
- `reference/three-layer-pattern.md` — Page → Dynamic → Cached pattern with `searchParams` variant.
- `reference/layouts.md` — non-blocking layout pattern with shared `'use cache'` helper.
- `reference/dynamic-segments.md` — Case 1 (`loading.tsx` + partial `generateStaticParams`) and Case 2 (layout with non-blocking dynamic `params`).

### Verification

- `SKILL.md`: 164 lines, description 487 chars (under the 1024 cap).
- All reference files: 103-214 lines (well under 500).
- All four reference files are linked directly from `SKILL.md` (no nested references).
- Reference files over 100 lines include a Contents list at the top.

## Test plan

- [ ] Trigger the skill with a query like "set up Sanity Live with cache components in this Next.js app" — verify Claude loads it.
- [ ] Trigger with a migration-flavored query like "migrate this app's `sanityFetch` calls to the three-layer pattern" — verify Claude loads it and follows the anti-pattern grep list.
- [ ] Trigger with "what's the difference between `sanityFetch` and `sanityFetchMetadata`" — verify Claude reads `reference/live-helpers.md`.
- [ ] Trigger with a `[slug]` page question — verify Claude reads `reference/three-layer-pattern.md` or `reference/dynamic-segments.md` as appropriate.

Made with [Cursor](https://cursor.com)