### PR TITLE
feat(next-sanity): brand sanityFetch data with stega string types

### DIFF
--- a/.changeset/stega-branded-sanityfetch.md
+++ b/.changeset/stega-branded-sanityfetch.md
@@ -1,0 +1,13 @@
+---
+"next-sanity": minor
+---
+
+feat: brand `sanityFetch` data with stega string types
+
+`defineLive().sanityFetch` now types `data` with the stega branded string types introduced in `@sanity/client@7.25.0`:
+
+- `stega: true` → `data` is `StegaBranded<ClientReturn<...>>`, so comparing possibly stega-encoded strings to literals is a compile error until cleaned with `stegaClean`
+- `stega: false` → `data` keeps clean TypeGen / `ClientReturn` types
+- `stega` as a non-literal `boolean`, or omitted → `data` is conservatively branded
+
+`stegaBrand` and the `ClientReturnStega`, `StegaBranded`, `StegaString`, and `StegaCleaned` types are now re-exported from the main `next-sanity` entry, alongside the existing `stegaClean` export.

--- a/packages/next-sanity/src/__tests__/exports.spec.ts
+++ b/packages/next-sanity/src/__tests__/exports.spec.ts
@@ -26,6 +26,7 @@ test(`exports snapshot for the ${JSON.stringify(env)} condition`, {timeout: 15_0
         isCorsOriginError: function
         mergeComponents: function
         PortableText: function
+        stegaBrand: function
         stegaClean: function
         toPlainText: function
         unstable__adapter: string

--- a/packages/next-sanity/src/client.ts
+++ b/packages/next-sanity/src/client.ts
@@ -1,3 +1,10 @@
 export type * from '@sanity/client'
 export {createClient, unstable__adapter, unstable__environment} from '@sanity/client'
-export {stegaClean} from '@sanity/client/stega'
+export {
+  stegaBrand,
+  stegaClean,
+  type ClientReturnStega,
+  type StegaBranded,
+  type StegaCleaned,
+  type StegaString,
+} from '@sanity/client/stega'

--- a/packages/next-sanity/src/live/conditions/default/index.ts
+++ b/packages/next-sanity/src/live/conditions/default/index.ts
@@ -18,6 +18,11 @@ import type {
  * `<SanityLive />`. Resolve dynamic values from `draftMode()` and `cookies()`
  * outside `'use cache'` boundaries, then pass them into cached components.
  *
+ * `sanityFetch` brands `data` with stega string types when `stega` is `true`,
+ * a non-literal `boolean`, or omitted (react-server may auto-enable stega).
+ * Pass the literal `stega: false` for clean TypeGen types. Use `stegaClean`
+ * before comparing branded strings to literals.
+ *
  * @see [Live Content API](https://www.sanity.io/docs/content-lake/live-content-api)
  * @see [Sanity Live](https://www.sanity.io/live)
  *
@@ -51,6 +56,7 @@ import type {
  * export interface DynamicFetchOptions {
  *   perspective: LivePerspective
  *   variant?: string
+ *   // `boolean` brands `sanityFetch` `data`; use literal `false` for clean types
  *   stega: boolean
  * }
  *

--- a/packages/next-sanity/src/live/conditions/next-js/defineLive.tsx
+++ b/packages/next-sanity/src/live/conditions/next-js/defineLive.tsx
@@ -25,6 +25,11 @@ import type {
  * `<SanityLive />`. Resolve dynamic values from `draftMode()` and `cookies()`
  * outside `'use cache'` boundaries, then pass them into cached components.
  *
+ * `sanityFetch` brands `data` with stega string types when `stega` is `true`,
+ * a non-literal `boolean`, or omitted (react-server may auto-enable stega).
+ * Pass the literal `stega: false` for clean TypeGen types. Use `stegaClean`
+ * before comparing branded strings to literals.
+ *
  * @see [Live Content API](https://www.sanity.io/docs/content-lake/live-content-api)
  * @see [Sanity Live](https://www.sanity.io/live)
  *
@@ -58,6 +63,7 @@ import type {
  * export interface DynamicFetchOptions {
  *   perspective: LivePerspective
  *   variant?: string
+ *   // `boolean` brands `sanityFetch` `data`; use literal `false` for clean types
  *   stega: boolean
  * }
  *

--- a/packages/next-sanity/src/live/conditions/react-server/defineLive.tsx
+++ b/packages/next-sanity/src/live/conditions/react-server/defineLive.tsx
@@ -27,6 +27,11 @@ import type {
  * `<SanityLive />`. Resolve dynamic values from `draftMode()` and `cookies()`
  * outside `'use cache'` boundaries, then pass them into cached components.
  *
+ * `sanityFetch` brands `data` with stega string types when `stega` is `true`,
+ * a non-literal `boolean`, or omitted (react-server may auto-enable stega).
+ * Pass the literal `stega: false` for clean TypeGen types. Use `stegaClean`
+ * before comparing branded strings to literals.
+ *
  * @see [Live Content API](https://www.sanity.io/docs/content-lake/live-content-api)
  * @see [Sanity Live](https://www.sanity.io/live)
  *
@@ -60,6 +65,7 @@ import type {
  * export interface DynamicFetchOptions {
  *   perspective: LivePerspective
  *   variant?: string
+ *   // `boolean` brands `sanityFetch` `data`; use literal `false` for clean types
  *   stega: boolean
  * }
  *

--- a/packages/next-sanity/src/live/shared/types.ts
+++ b/packages/next-sanity/src/live/shared/types.ts
@@ -1,3 +1,4 @@
+import type {StegaBranded} from '@sanity/client/stega'
 import type {
   ClientPerspective,
   ClientReturn,
@@ -9,19 +10,28 @@ import type {
 } from 'next-sanity'
 
 /**
+ * Like `ClientReturnStega` from `@sanity/client/stega`, but composed from the
+ * main-entry {@link ClientReturn} so `SanityQueries` TypeGen augmentations on
+ * `@sanity/client` apply. The stega subpath ships a bundled `ClientReturn` that
+ * does not see those augmentations.
+ */
+type FetchClientReturnStega<QueryString extends string> = StegaBranded<
+  ClientReturn<QueryString, unknown>
+>
+
+/**
  * Perspectives supported by Sanity Live.
  * Using the legacy `'raw'` perspective is not supported and leads to undefined behavior.
  */
 export type LivePerspective = Exclude<ClientPerspective, 'raw'>
 
-/**
- * Fetches data through the configured Sanity client and returns the result
- * together with the source map and cache tags that Sanity Live uses for
- * targeted revalidation.
- *
- * Returned by `defineLive({strict: false})` and `defineLive({strict: undefined})`.
- */
-export type DefinedFetchType = <const QueryString extends string>(options: {
+type DefinedFetchResult<Data> = Promise<{
+  data: Data
+  sourceMap: ContentSourceMap | null
+  tags: string[]
+}>
+
+type DefinedFetchSharedOptions<QueryString extends string> = {
   /**
    * GROQ query to execute.
    */
@@ -30,22 +40,6 @@ export type DefinedFetchType = <const QueryString extends string>(options: {
    * Parameters used by the GROQ query.
    */
   params?: QueryParams | Promise<QueryParams>
-  /**
-   * Content perspective used for the fetch.
-   *
-   * @remarks
-   * Requires `serverToken` to be configured in `defineLive()`
-   *
-   * @defaultValue
-   * The default is `'published'` unless
-   *  - `Cache Components` are disabled
-   *  - `defineLive()` was given a `serverToken`
-   *  - `defineLive()` is not set to `strict: true`
-   *  - `draftMode()` is enabled
-   *
-   * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-perspective'` cookie and fall back to `'drafts'` if not set
-   */
-  perspective?: LivePerspective
   /**
    * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
    *
@@ -63,24 +57,6 @@ export type DefinedFetchType = <const QueryString extends string>(options: {
    * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-variant'` cookie and fall back to `undefined` if not set
    */
   variant?: string
-  /**
-   * Enables stega encoding of the data. This is typically only used in draft
-   * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
-   *
-   * @remarks
-   * Requires `serverToken` to be configured in `defineLive()`
-   *
-   * @defaultValue
-   * The default is `false` unless
-   *  - `Cache Components` are disabled
-   *  - `defineLive()` was given a `serverToken`
-   *  - `defineLive()` is not set to `strict: true`
-   *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
-   *  - `draftMode()` is enabled
-   *
-   * If all of the above conditions are met, then the default value will be `true`
-   */
-  stega?: boolean
   /**
    * Additional cache tags to associate with this fetch.
    *
@@ -105,11 +81,108 @@ export type DefinedFetchType = <const QueryString extends string>(options: {
    * otherwise it's `'next-loader.fetch'`
    */
   requestTag?: string
-}) => Promise<{
-  data: ClientReturn<QueryString, unknown>
-  sourceMap: ContentSourceMap | null
-  tags: string[]
-}>
+}
+
+/**
+ * Content perspective used for the fetch.
+ *
+ * @remarks
+ * Requires `serverToken` to be configured in `defineLive()`
+ *
+ * @defaultValue
+ * The default is `'published'` unless
+ *  - `Cache Components` are disabled
+ *  - `defineLive()` was given a `serverToken`
+ *  - `defineLive()` is not set to `strict: true`
+ *  - `draftMode()` is enabled
+ *
+ * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-perspective'` cookie and fall back to `'drafts'` if not set
+ */
+type DefinedFetchPerspectiveOption = {
+  perspective?: LivePerspective
+}
+
+/**
+ * Enables stega encoding of the data. This is typically only used in draft
+ * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+ *
+ * Return `data` is stega-branded (`StegaBranded<ClientReturn<...>>`) when
+ * `stega` is `true`, a non-literal `boolean`, or omitted (react-server may
+ * auto-enable stega in draft mode). Pass the literal `stega: false` for clean
+ * {@link ClientReturn} types.
+ *
+ * @remarks
+ * Requires `serverToken` to be configured in `defineLive()`
+ *
+ * @defaultValue
+ * The default is `false` unless
+ *  - `Cache Components` are disabled
+ *  - `defineLive()` was given a `serverToken`
+ *  - `defineLive()` is not set to `strict: true`
+ *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
+ *  - `draftMode()` is enabled
+ *
+ * If all of the above conditions are met, then the default value will be `true`
+ */
+type DefinedFetchStegaDoc = {
+  stega?: boolean
+}
+
+/**
+ * Fetches data through the configured Sanity client and returns the result
+ * together with the source map and cache tags that Sanity Live uses for
+ * targeted revalidation.
+ *
+ * Returned by `defineLive({strict: false})` and `defineLive({strict: undefined})`.
+ *
+ * Overloads brand `data` with stega string types when stega may be enabled
+ * (`stega: true`, a non-literal `boolean`, or omitted). Literal `stega: false`
+ * keeps clean TypeGen / {@link ClientReturn} types.
+ */
+export type DefinedFetchType = {
+  <const QueryString extends string>(
+    options: DefinedFetchSharedOptions<QueryString> &
+      DefinedFetchPerspectiveOption & {
+        /**
+         * Enables stega encoding of the data. This is typically only used in draft
+         * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+         *
+         * When `true`, `data` is stega-branded (`StegaBranded<ClientReturn<...>>`).
+         *
+         * @remarks
+         * Requires `serverToken` to be configured in `defineLive()`
+         */
+        stega: true
+      },
+  ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
+  <const QueryString extends string>(
+    options: DefinedFetchSharedOptions<QueryString> &
+      DefinedFetchPerspectiveOption & {
+        /**
+         * Disables stega encoding. `data` keeps clean {@link ClientReturn} types.
+         *
+         * @remarks
+         * Requires `serverToken` to be configured in `defineLive()`
+         *
+         * @defaultValue
+         * The default is `false` unless
+         *  - `Cache Components` are disabled
+         *  - `defineLive()` was given a `serverToken`
+         *  - `defineLive()` is not set to `strict: true`
+         *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
+         *  - `draftMode()` is enabled
+         *
+         * If all of the above conditions are met, then the default value will be `true`
+         */
+        stega: false
+      },
+  ): DefinedFetchResult<ClientReturn<QueryString, unknown>>
+  <const QueryString extends string>(
+    options: DefinedFetchSharedOptions<QueryString> &
+      DefinedFetchPerspectiveOption &
+      DefinedFetchStegaDoc,
+  ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
+}
 
 /**
  * Render this in your root layout.tsx to make your page refresh, or revalidate, on new content live, automatically.
@@ -226,27 +299,87 @@ export interface StrictDefinedLiveProps extends Omit<DefinedLiveProps, 'includeD
 /**
  * Like {@link DefinedFetchType} but with `perspective` and `stega` required.
  * Returned by `defineLive({strict: true})`.
+ *
+ * Overloads brand `data` with stega string types when stega may be enabled
+ * (`stega: true` or a non-literal `boolean`). Literal `stega: false` keeps
+ * clean TypeGen / {@link ClientReturn} types.
  */
-export type StrictDefinedFetchType = <const QueryString extends string>(options: {
-  query: QueryString
-  params?: QueryParams | Promise<QueryParams>
-  perspective: LivePerspective
-  /**
-   * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
-   *
-   * Stays optional in strict mode: the absence of a variant is a valid state
-   * (base content). With `strict: true` there is no cookie auto-resolution;
-   * only the explicit option is used.
-   */
-  variant?: string
-  stega: boolean
-  tags?: string[]
-  requestTag?: string
-}) => Promise<{
-  data: ClientReturn<QueryString, unknown>
-  sourceMap: ContentSourceMap | null
-  tags: string[]
-}>
+export type StrictDefinedFetchType = {
+  <const QueryString extends string>(
+    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
+      /**
+       * Content perspective used for the fetch.
+       *
+       * Required when `strict: true` is set on `defineLive()`.
+       */
+      perspective: LivePerspective
+      /**
+       * Enables stega encoding of the data. This is typically only used in draft
+       * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+       *
+       * When `true`, `data` is stega-branded (`StegaBranded<ClientReturn<...>>`).
+       */
+      stega: true
+      /**
+       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
+       *
+       * Stays optional in strict mode: the absence of a variant is a valid state
+       * (base content). With `strict: true` there is no cookie auto-resolution;
+       * only the explicit option is used.
+       */
+      variant?: string
+    },
+  ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
+  <const QueryString extends string>(
+    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
+      /**
+       * Content perspective used for the fetch.
+       *
+       * Required when `strict: true` is set on `defineLive()`.
+       */
+      perspective: LivePerspective
+      /**
+       * Disables stega encoding. `data` keeps clean {@link ClientReturn} types.
+       */
+      stega: false
+      /**
+       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
+       *
+       * Stays optional in strict mode: the absence of a variant is a valid state
+       * (base content). With `strict: true` there is no cookie auto-resolution;
+       * only the explicit option is used.
+       */
+      variant?: string
+    },
+  ): DefinedFetchResult<ClientReturn<QueryString, unknown>>
+  <const QueryString extends string>(
+    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
+      /**
+       * Content perspective used for the fetch.
+       *
+       * Required when `strict: true` is set on `defineLive()`.
+       */
+      perspective: LivePerspective
+      /**
+       * Enables stega encoding of the data. This is typically only used in draft
+       * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+       *
+       * When a non-literal `boolean`, `data` is stega-branded
+       * (`StegaBranded<ClientReturn<...>>`) — conservative: treat strings as
+       * possibly stega-encoded.
+       */
+      stega: boolean
+      /**
+       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
+       *
+       * Stays optional in strict mode: the absence of a variant is a valid state
+       * (base content). With `strict: true` there is no cookie auto-resolution;
+       * only the explicit option is used.
+       */
+      variant?: string
+    },
+  ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
+}
 
 export interface SanityClientConfig extends Pick<
   InitializedClientConfig,

--- a/packages/next-sanity/src/live/shared/types.ts
+++ b/packages/next-sanity/src/live/shared/types.ts
@@ -31,7 +31,11 @@ type DefinedFetchResult<Data> = Promise<{
   tags: string[]
 }>
 
-type DefinedFetchSharedOptions<QueryString extends string> = {
+/**
+ * Options accepted by `sanityFetch()` returned by `defineLive({strict: false})`
+ * and `defineLive({strict: undefined})`.
+ */
+interface DefinedFetchOptions<QueryString extends string> {
   /**
    * GROQ query to execute.
    */
@@ -40,6 +44,22 @@ type DefinedFetchSharedOptions<QueryString extends string> = {
    * Parameters used by the GROQ query.
    */
   params?: QueryParams | Promise<QueryParams>
+  /**
+   * Content perspective used for the fetch.
+   *
+   * @remarks
+   * Requires `serverToken` to be configured in `defineLive()`
+   *
+   * @defaultValue
+   * The default is `'published'` unless
+   *  - `Cache Components` are disabled
+   *  - `defineLive()` was given a `serverToken`
+   *  - `defineLive()` is not set to `strict: true`
+   *  - `draftMode()` is enabled
+   *
+   * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-perspective'` cookie and fall back to `'drafts'` if not set
+   */
+  perspective?: LivePerspective
   /**
    * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
    *
@@ -57,6 +77,30 @@ type DefinedFetchSharedOptions<QueryString extends string> = {
    * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-variant'` cookie and fall back to `undefined` if not set
    */
   variant?: string
+  /**
+   * Enables stega encoding of the data. This is typically only used in draft
+   * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+   *
+   * Unless this option is the literal `false`, the returned `data` is
+   * stega-branded (`StegaBranded<ClientReturn<...>>`): strings that may carry
+   * stega payloads are typed as `StegaString` and must be cleaned with
+   * `stegaClean` before they can be compared against string literals. Pass the
+   * literal `stega: false` to keep clean TypeGen / {@link ClientReturn} types.
+   *
+   * @remarks
+   * Requires `serverToken` to be configured in `defineLive()`
+   *
+   * @defaultValue
+   * The default is `false` unless
+   *  - `Cache Components` are disabled
+   *  - `defineLive()` was given a `serverToken`
+   *  - `defineLive()` is not set to `strict: true`
+   *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
+   *  - `draftMode()` is enabled
+   *
+   * If all of the above conditions are met, then the default value will be `true`
+   */
+  stega?: boolean
   /**
    * Additional cache tags to associate with this fetch.
    *
@@ -84,48 +128,38 @@ type DefinedFetchSharedOptions<QueryString extends string> = {
 }
 
 /**
- * Content perspective used for the fetch.
- *
- * @remarks
- * Requires `serverToken` to be configured in `defineLive()`
- *
- * @defaultValue
- * The default is `'published'` unless
- *  - `Cache Components` are disabled
- *  - `defineLive()` was given a `serverToken`
- *  - `defineLive()` is not set to `strict: true`
- *  - `draftMode()` is enabled
- *
- * If all of the above conditions are met, then the default value will be resolved from attempting to read the `'sanity-preview-perspective'` cookie and fall back to `'drafts'` if not set
+ * Like {@link DefinedFetchOptions} but with `stega` fixed to `true`, selecting
+ * the overload that brands the returned `data` with stega string types.
+ * All other options inherit their documentation from {@link DefinedFetchOptions}.
  */
-type DefinedFetchPerspectiveOption = {
-  perspective?: LivePerspective
+interface DefinedFetchStegaEnabledOptions<QueryString extends string>
+  extends DefinedFetchOptions<QueryString> {
+  /**
+   * Enables stega encoding of the data. This is typically only used in draft
+   * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+   *
+   * With the literal `true`, the returned `data` is stega-branded
+   * (`StegaBranded<ClientReturn<...>>`): use `stegaClean` before comparing
+   * strings against literals.
+   *
+   * @remarks
+   * Requires `serverToken` to be configured in `defineLive()`
+   */
+  stega: true
 }
 
 /**
- * Enables stega encoding of the data. This is typically only used in draft
- * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
- *
- * Return `data` is stega-branded (`StegaBranded<ClientReturn<...>>`) when
- * `stega` is `true`, a non-literal `boolean`, or omitted (react-server may
- * auto-enable stega in draft mode). Pass the literal `stega: false` for clean
- * {@link ClientReturn} types.
- *
- * @remarks
- * Requires `serverToken` to be configured in `defineLive()`
- *
- * @defaultValue
- * The default is `false` unless
- *  - `Cache Components` are disabled
- *  - `defineLive()` was given a `serverToken`
- *  - `defineLive()` is not set to `strict: true`
- *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
- *  - `draftMode()` is enabled
- *
- * If all of the above conditions are met, then the default value will be `true`
+ * Like {@link DefinedFetchOptions} but with `stega` fixed to `false`, selecting
+ * the overload that keeps the returned `data` free of stega branding.
+ * All other options inherit their documentation from {@link DefinedFetchOptions}.
  */
-type DefinedFetchStegaDoc = {
-  stega?: boolean
+interface DefinedFetchStegaDisabledOptions<QueryString extends string>
+  extends DefinedFetchOptions<QueryString> {
+  /**
+   * Disables stega encoding for this fetch. The returned `data` keeps clean
+   * TypeGen / {@link ClientReturn} types, no `stegaClean` needed.
+   */
+  stega: false
 }
 
 /**
@@ -141,46 +175,13 @@ type DefinedFetchStegaDoc = {
  */
 export type DefinedFetchType = {
   <const QueryString extends string>(
-    options: DefinedFetchSharedOptions<QueryString> &
-      DefinedFetchPerspectiveOption & {
-        /**
-         * Enables stega encoding of the data. This is typically only used in draft
-         * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
-         *
-         * When `true`, `data` is stega-branded (`StegaBranded<ClientReturn<...>>`).
-         *
-         * @remarks
-         * Requires `serverToken` to be configured in `defineLive()`
-         */
-        stega: true
-      },
+    options: DefinedFetchStegaEnabledOptions<QueryString>,
   ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
   <const QueryString extends string>(
-    options: DefinedFetchSharedOptions<QueryString> &
-      DefinedFetchPerspectiveOption & {
-        /**
-         * Disables stega encoding. `data` keeps clean {@link ClientReturn} types.
-         *
-         * @remarks
-         * Requires `serverToken` to be configured in `defineLive()`
-         *
-         * @defaultValue
-         * The default is `false` unless
-         *  - `Cache Components` are disabled
-         *  - `defineLive()` was given a `serverToken`
-         *  - `defineLive()` is not set to `strict: true`
-         *  - `defineLive()` was given a `client` that defines `stega.studioUrl`
-         *  - `draftMode()` is enabled
-         *
-         * If all of the above conditions are met, then the default value will be `true`
-         */
-        stega: false
-      },
+    options: DefinedFetchStegaDisabledOptions<QueryString>,
   ): DefinedFetchResult<ClientReturn<QueryString, unknown>>
   <const QueryString extends string>(
-    options: DefinedFetchSharedOptions<QueryString> &
-      DefinedFetchPerspectiveOption &
-      DefinedFetchStegaDoc,
+    options: DefinedFetchOptions<QueryString>,
   ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
 }
 
@@ -297,6 +298,81 @@ export interface StrictDefinedLiveProps extends Omit<DefinedLiveProps, 'includeD
 }
 
 /**
+ * Options accepted by `sanityFetch()` returned by `defineLive({strict: true})`.
+ * Like {@link DefinedFetchOptions} but with `perspective` and `stega` required,
+ * and no cookie or `draftMode()` auto-resolution of defaults.
+ */
+interface StrictDefinedFetchOptions<QueryString extends string>
+  extends DefinedFetchOptions<QueryString> {
+  /**
+   * Content perspective used for the fetch.
+   *
+   * Required when `strict: true` is set on `defineLive()`: there is no cookie
+   * auto-resolution; only the explicit option is used.
+   *
+   * @remarks
+   * Non-`'published'` perspectives require `serverToken` to be configured in `defineLive()`
+   */
+  perspective: LivePerspective
+  /**
+   * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
+   *
+   * Stays optional in strict mode: the absence of a variant is a valid state
+   * (base content). With `strict: true` there is no cookie auto-resolution;
+   * only the explicit option is used.
+   */
+  variant?: string
+  /**
+   * Enables stega encoding of the data. This is typically only used in draft
+   * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+   *
+   * Required when `strict: true` is set on `defineLive()`. Unless this option
+   * is the literal `false`, the returned `data` is stega-branded
+   * (`StegaBranded<ClientReturn<...>>`) — conservative: treat strings as
+   * possibly stega-encoded until cleaned with `stegaClean`.
+   *
+   * @remarks
+   * Requires `serverToken` to be configured in `defineLive()`
+   */
+  stega: boolean
+}
+
+/**
+ * Like {@link StrictDefinedFetchOptions} but with `stega` fixed to `true`,
+ * selecting the overload that brands the returned `data` with stega string types.
+ * All other options inherit their documentation from {@link StrictDefinedFetchOptions}.
+ */
+interface StrictDefinedFetchStegaEnabledOptions<QueryString extends string>
+  extends StrictDefinedFetchOptions<QueryString> {
+  /**
+   * Enables stega encoding of the data. This is typically only used in draft
+   * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
+   *
+   * With the literal `true`, the returned `data` is stega-branded
+   * (`StegaBranded<ClientReturn<...>>`): use `stegaClean` before comparing
+   * strings against literals.
+   *
+   * @remarks
+   * Requires `serverToken` to be configured in `defineLive()`
+   */
+  stega: true
+}
+
+/**
+ * Like {@link StrictDefinedFetchOptions} but with `stega` fixed to `false`,
+ * selecting the overload that keeps the returned `data` free of stega branding.
+ * All other options inherit their documentation from {@link StrictDefinedFetchOptions}.
+ */
+interface StrictDefinedFetchStegaDisabledOptions<QueryString extends string>
+  extends StrictDefinedFetchOptions<QueryString> {
+  /**
+   * Disables stega encoding for this fetch. The returned `data` keeps clean
+   * TypeGen / {@link ClientReturn} types, no `stegaClean` needed.
+   */
+  stega: false
+}
+
+/**
  * Like {@link DefinedFetchType} but with `perspective` and `stega` required.
  * Returned by `defineLive({strict: true})`.
  *
@@ -306,78 +382,13 @@ export interface StrictDefinedLiveProps extends Omit<DefinedLiveProps, 'includeD
  */
 export type StrictDefinedFetchType = {
   <const QueryString extends string>(
-    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
-      /**
-       * Content perspective used for the fetch.
-       *
-       * Required when `strict: true` is set on `defineLive()`.
-       */
-      perspective: LivePerspective
-      /**
-       * Enables stega encoding of the data. This is typically only used in draft
-       * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
-       *
-       * When `true`, `data` is stega-branded (`StegaBranded<ClientReturn<...>>`).
-       */
-      stega: true
-      /**
-       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
-       *
-       * Stays optional in strict mode: the absence of a variant is a valid state
-       * (base content). With `strict: true` there is no cookie auto-resolution;
-       * only the explicit option is used.
-       */
-      variant?: string
-    },
+    options: StrictDefinedFetchStegaEnabledOptions<QueryString>,
   ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
   <const QueryString extends string>(
-    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
-      /**
-       * Content perspective used for the fetch.
-       *
-       * Required when `strict: true` is set on `defineLive()`.
-       */
-      perspective: LivePerspective
-      /**
-       * Disables stega encoding. `data` keeps clean {@link ClientReturn} types.
-       */
-      stega: false
-      /**
-       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
-       *
-       * Stays optional in strict mode: the absence of a variant is a valid state
-       * (base content). With `strict: true` there is no cookie auto-resolution;
-       * only the explicit option is used.
-       */
-      variant?: string
-    },
+    options: StrictDefinedFetchStegaDisabledOptions<QueryString>,
   ): DefinedFetchResult<ClientReturn<QueryString, unknown>>
   <const QueryString extends string>(
-    options: Omit<DefinedFetchSharedOptions<QueryString>, 'variant'> & {
-      /**
-       * Content perspective used for the fetch.
-       *
-       * Required when `strict: true` is set on `defineLive()`.
-       */
-      perspective: LivePerspective
-      /**
-       * Enables stega encoding of the data. This is typically only used in draft
-       * mode with `perspective: 'drafts'` and `@sanity/visual-editing`.
-       *
-       * When a non-literal `boolean`, `data` is stega-branded
-       * (`StegaBranded<ClientReturn<...>>`) — conservative: treat strings as
-       * possibly stega-encoded.
-       */
-      stega: boolean
-      /**
-       * Editing variant used for the fetch, as the bare variant id (e.g. `Ab12cd34`).
-       *
-       * Stays optional in strict mode: the absence of a variant is a valid state
-       * (base content). With `strict: true` there is no cookie auto-resolution;
-       * only the explicit option is used.
-       */
-      variant?: string
-    },
+    options: StrictDefinedFetchOptions<QueryString>,
   ): DefinedFetchResult<FetchClientReturnStega<QueryString>>
 }
 

--- a/packages/next-sanity/test/sanityFetch.stega-types.test.ts
+++ b/packages/next-sanity/test/sanityFetch.stega-types.test.ts
@@ -30,7 +30,7 @@ describe('DefinedFetchType stega branding', () => {
     }
     type Data = Awaited<ReturnType<typeof sample>>['data']
     expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
-    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString>()
     expectTypeOf<Data['_type']>().toEqualTypeOf<'post'>()
     expectTypeOf<Data['imageLocation']>().not.toEqualTypeOf<'left' | 'right'>()
   })
@@ -52,7 +52,7 @@ describe('DefinedFetchType stega branding', () => {
     }
     type Data = Awaited<ReturnType<typeof sample>>['data']
     expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
-    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString>()
     expectTypeOf<Data['imageLocation']>().not.toEqualTypeOf<'left' | 'right'>()
   })
 
@@ -62,7 +62,7 @@ describe('DefinedFetchType stega branding', () => {
     }
     type Data = Awaited<ReturnType<typeof sample>>['data']
     expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
-    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString>()
   })
 })
 
@@ -92,7 +92,7 @@ describe('StrictDefinedFetchType stega branding', () => {
     }
     type Data = Awaited<ReturnType<typeof sample>>['data']
     expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
-    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString>()
   })
 
   test('requires stega', () => {

--- a/packages/next-sanity/test/sanityFetch.stega-types.test.ts
+++ b/packages/next-sanity/test/sanityFetch.stega-types.test.ts
@@ -1,0 +1,105 @@
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {DefinedFetchType, StrictDefinedFetchType} from '#live/types'
+
+import type {ClientReturn, StegaBranded, StegaString} from '../src/client'
+
+declare module '@sanity/client' {
+  interface SanityQueries {
+    '*[_type=="post"][0]{title,imageLocation}': {
+      _type: 'post'
+      title: string
+      imageLocation: 'left' | 'right'
+    }
+  }
+}
+
+const query = '*[_type=="post"][0]{title,imageLocation}' as const
+
+type CleanData = ClientReturn<typeof query, unknown>
+type BrandedData = StegaBranded<CleanData>
+
+// Type-only bindings — erased at runtime; nested samples below are never called.
+declare const sanityFetch: DefinedFetchType
+declare const strictFetch: StrictDefinedFetchType
+
+describe('DefinedFetchType stega branding', () => {
+  test('stega: true returns branded data', () => {
+    async function sample() {
+      return sanityFetch({query, stega: true})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['_type']>().toEqualTypeOf<'post'>()
+    expectTypeOf<Data['imageLocation']>().not.toEqualTypeOf<'left' | 'right'>()
+  })
+
+  test('stega: false returns clean ClientReturn', () => {
+    async function sample() {
+      return sanityFetch({query, stega: false})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<CleanData>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<string>()
+    expectTypeOf<Data['imageLocation']>().toEqualTypeOf<'left' | 'right'>()
+  })
+
+  test('stega: boolean returns branded data', () => {
+    async function sample() {
+      const stega = true as boolean
+      return sanityFetch({query, stega})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+    expectTypeOf<Data['imageLocation']>().not.toEqualTypeOf<'left' | 'right'>()
+  })
+
+  test('omitted stega returns branded data', () => {
+    async function sample() {
+      return sanityFetch({query})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+  })
+})
+
+describe('StrictDefinedFetchType stega branding', () => {
+  test('stega: true returns branded data', () => {
+    async function sample() {
+      return strictFetch({query, perspective: 'published', stega: true})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
+    expectTypeOf<Data['imageLocation']>().not.toEqualTypeOf<'left' | 'right'>()
+  })
+
+  test('stega: false returns clean ClientReturn', () => {
+    async function sample() {
+      return strictFetch({query, perspective: 'published', stega: false})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<CleanData>()
+    expectTypeOf<Data['imageLocation']>().toEqualTypeOf<'left' | 'right'>()
+  })
+
+  test('stega: boolean returns branded data', () => {
+    async function sample() {
+      const stega = false as boolean
+      return strictFetch({query, perspective: 'drafts', stega})
+    }
+    type Data = Awaited<ReturnType<typeof sample>>['data']
+    expectTypeOf<Data>().toEqualTypeOf<BrandedData>()
+    expectTypeOf<Data['title']>().toEqualTypeOf<StegaString<string>>()
+  })
+
+  test('requires stega', () => {
+    async function sample() {
+      // @ts-expect-error stega is required in strict mode
+      return strictFetch({query, perspective: 'published'})
+    }
+    void sample
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bakes `@sanity/client` stega branded string types into `defineLive().sanityFetch` via call-signature overloads:

- `stega: true` → `StegaBranded<ClientReturn<...>>`
- `stega: false` → clean `ClientReturn<...>`
- `stega: boolean` or omitted → branded (conservative; covers draft/auto-enable paths)

Also re-exports `stegaBrand`, `ClientReturnStega`, `StegaBranded`, `StegaString`, and `StegaCleaned` from the main `next-sanity` entry (alongside existing `stegaClean`).

## Notes

Branding uses `StegaBranded<ClientReturn<Q, unknown>>` composed from the main `@sanity/client` entry so TypeGen `SanityQueries` augmentations apply. The published `@sanity/client/stega` `ClientReturnStega` alias bundles its own `ClientReturn`/`SanityQueries` and would not see those augmentations.

## Test plan

- [x] Unit tests pass (`pnpm test --run` in `packages/next-sanity`)
- [x] `tsc --noEmit` passes, including new `sanityFetch.stega-types.test.ts` overload coverage
- [x] Exports snapshot updated for `stegaBrand`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a85f7ac-dac7-4b76-b714-630b5a8a39b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a85f7ac-dac7-4b76-b714-630b5a8a39b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

