### PR TITLE
fix(next-sanity): accept stega branded `sanityFetch` data in `PortableText` `Infer*` types

### DIFF
--- a/.changeset/bump-sanity-client-7-26-1.md
+++ b/.changeset/bump-sanity-client-7-26-1.md
@@ -1,0 +1,7 @@
+---
+"next-sanity": patch
+---
+
+fix(deps): update dependency @sanity/client to ^7.26.1
+
+`@sanity/client@7.26.1` stops `StegaBranded` from branding symbol-keyed properties like the `internalGroqTypeReferenceTo` marker Sanity TypeGen puts on dereferenced references. Stega-branded `sanityFetch` data is now assignable to clean-typed props (like TypeGen query result types) whenever the real string fields are plain `string`, without `stegaClean`.

--- a/.changeset/stega-aware-portable-text-infer.md
+++ b/.changeset/stega-aware-portable-text-infer.md
@@ -1,0 +1,22 @@
+---
+"next-sanity": patch
+---
+
+fix: accept stega branded `sanityFetch` data in `<PortableText>` `Infer*` types
+
+The `InferValue`, `InferComponents` and `InferStrictComponents` types re-exported from the main `next-sanity` entry are now stega-aware. They shadow the `@portabletext/react` versions and widen the inferred types to cover both the clean TypeGen shape (`sanityFetch` with `stega: false`) and the stega-branded shape that `sanityFetch` returns when stega may be enabled (introduced in `next-sanity@13.3.0`).
+
+Re-usable components typed with `InferValue` no longer fail to type-check when given stega-branded data:
+
+```tsx
+import {PortableText, type InferStrictComponents, type InferValue, type SanityQueries} from 'next-sanity'
+
+export function CustomPortableText(props: {value: InferValue<SanityQueries[keyof SanityQueries]>}) {
+  const components = {
+    // …
+  } satisfies InferStrictComponents<typeof props.value>
+  return <PortableText components={components} value={props.value} />
+}
+```
+
+Previously the branded data had to be cleaned wholesale (`value={stegaClean(props.value)}`), which strips the hidden characters `@sanity/visual-editing` uses to make each paragraph clickable in Visual Editing. Strings inside component handler props stay branded, keep rendering them as-is and use `stegaClean` on the individual values you compare against string literals.

--- a/.changeset/stega-aware-portable-text-infer.md
+++ b/.changeset/stega-aware-portable-text-infer.md
@@ -9,7 +9,12 @@ The `InferValue`, `InferComponents` and `InferStrictComponents` types re-exporte
 Re-usable components typed with `InferValue` no longer fail to type-check when given stega-branded data:
 
 ```tsx
-import {PortableText, type InferStrictComponents, type InferValue, type SanityQueries} from 'next-sanity'
+import {
+  PortableText,
+  type InferStrictComponents,
+  type InferValue,
+  type SanityQueries,
+} from "next-sanity"
 
 export function CustomPortableText(props: {value: InferValue<SanityQueries[keyof SanityQueries]>}) {
   const components = {

--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@portabletext/react": "^7.0.1",
-    "@sanity/client": "^7.26.0",
+    "@sanity/client": "^7.26.1",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/preview-url-secret": "^4.1.2",
     "@sanity/visual-editing": "^5.7.3",
@@ -123,7 +123,7 @@
     "vitest-package-exports": "^1.2.0"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.0",
+    "@sanity/client": "^7.26.1",
     "next": "^16.0.0-0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/packages/next-sanity/src/index.ts
+++ b/packages/next-sanity/src/index.ts
@@ -1,6 +1,9 @@
 export * from './client'
 export * from './create-data-attribute'
 export * from '@portabletext/react'
+// Shadows the `Infer*` types from `@portabletext/react` with stega-aware
+// versions that accept both clean and stega-branded `sanityFetch` results.
+export type {InferComponents, InferStrictComponents, InferValue} from './portable-text'
 export {defineQuery, default as groq} from 'groq'
 export {isCorsOriginError} from '#live/isCorsOriginError'
 export {variantsApiVersion} from './variants/constants'

--- a/packages/next-sanity/src/portable-text.ts
+++ b/packages/next-sanity/src/portable-text.ts
@@ -1,0 +1,132 @@
+import type {
+  InferComponents as PortableTextInferComponents,
+  InferStrictComponents as PortableTextInferStrictComponents,
+  InferValue as PortableTextInferValue,
+} from '@portabletext/react'
+import type {StegaBranded, StegaCleaned} from '@sanity/client/stega'
+
+/**
+ * Widens a query result type to cover both sides of stega branding:
+ * the clean TypeGen shape (`sanityFetch` with `stega: false`) and the
+ * stega-branded shape (`sanityFetch` when stega may be enabled).
+ *
+ * This is what lets the `Infer*` types accept `data` from any `sanityFetch`
+ * call without requiring a wholesale `stegaClean()`, which would strip the
+ * hidden characters Visual Editing needs to make each paragraph clickable.
+ */
+type StegaAware<T> = StegaCleaned<T> | StegaBranded<T>
+
+/**
+ * Infer the Portable Text array value type from
+ * {@link https://www.sanity.io/docs/apis-and-sdks/sanity-typegen | Sanity TypeGen}
+ * generated types.
+ *
+ * Stega-aware version of `InferValue` from `@portabletext/react`: the inferred
+ * value type accepts both clean query results (`sanityFetch` with
+ * `stega: false`) and stega-branded results (`sanityFetch` when stega may be
+ * enabled). Don't clean the value with `stegaClean()` before rendering it,
+ * that strips the hidden characters `@sanity/visual-editing` uses to make each
+ * paragraph clickable. Instead, use `stegaClean` on individual strings at the
+ * point where they're compared against literals.
+ *
+ * Useful when building a re-usable wrapper component that only takes `value`
+ * as an input prop and sets up `components` internally. Pass a TypeGen-
+ * generated query result type that contains Portable Text fields - such as
+ * an individual query result like `PostQueryResult`, or the `SanityQueries`
+ * interface from `@sanity/client` - and `InferValue<T>` returns an array type
+ * containing every Portable Text item shape it can find.
+ *
+ * Always feed `InferValue<T>` query result types, not Sanity schema types.
+ * Schema types describe how content is stored, which can differ from how it
+ * is queried (e.g. references resolved with `->`).
+ *
+ * @example
+ * ```tsx
+ * // Re-usable component typed against every registered query. Relies on
+ * // `overloadClientMethods` being enabled in `sanity.cli.ts#typegen` (the default).
+ * import {
+ *   PortableText,
+ *   type InferStrictComponents,
+ *   type InferValue,
+ *   type SanityQueries,
+ * } from 'next-sanity'
+ *
+ * type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+ *
+ * export function CustomPortableText(props: {value: PortableTextValue}) {
+ *   const components = {
+ *     types: {
+ *       // custom types are autocompleted and fully typed
+ *     },
+ *   } satisfies InferStrictComponents<PortableTextValue>
+ *
+ *   return <PortableText components={components} value={props.value} />
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Rendering `sanityFetch` results, with or without stega, type-checks:
+ * const {data} = await sanityFetch({query: postQuery, params})
+ * return Array.isArray(data?.content) && <CustomPortableText value={data.content} />
+ * ```
+ */
+export type InferValue<T> = PortableTextInferValue<StegaAware<T>>
+
+/**
+ * Infer Portable Text components from a value type. This matches the inference
+ * behavior of the `components` prop on `<PortableText>`.
+ *
+ * Stega-aware version of `InferComponents` from `@portabletext/react`: the
+ * inferred component props cover both clean query results (`sanityFetch` with
+ * `stega: false`) and stega-branded results (`sanityFetch` when stega may be
+ * enabled), so the same `components` object can render both. Strings that may
+ * carry stega payloads stay branded inside component props: render them as-is
+ * to keep Visual Editing working, and use `stegaClean` on the individual
+ * values you compare against string literals.
+ *
+ * This is useful when working with
+ * {@link https://www.sanity.io/docs/apis-and-sdks/sanity-typegen | Sanity TypeGen},
+ * where `defineQuery()` and `sanityFetch()` can infer the shape of Portable
+ * Text fields.
+ *
+ * @example
+ * ```tsx
+ * import {PortableText, type InferComponents, defineQuery} from 'next-sanity'
+ * import {sanityFetch} from '@/sanity/lib/live'
+ *
+ * export default async function Page({slug}: {slug: string}) {
+ *   const query = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title,content}`)
+ *   const {data} = await sanityFetch({query, params: {slug}})
+ *   const components = {
+ *     block: {
+ *       // custom types are autocompleted and fully typed
+ *     },
+ *   } satisfies InferComponents<typeof data.content>
+ *
+ *   return (
+ *     <>
+ *       ...
+ *       {Array.isArray(data?.content) && <PortableText components={components} value={data.content} />}
+ *     </>
+ *   )
+ * }
+ * ```
+ */
+export type InferComponents<T> = PortableTextInferComponents<StegaAware<T>>
+
+/**
+ * Infer Portable Text components from a value type, requiring handlers for all
+ * custom object types and disallowing extra custom object type handlers.
+ *
+ * Stega-aware version of `InferStrictComponents` from `@portabletext/react`,
+ * see {@link InferComponents} for how stega branding is handled.
+ *
+ * This is used the same way as {@link InferComponents}, but serves a different
+ * purpose: `InferComponents` is forgiving and mirrors the inline
+ * `<PortableText components={...} />` experience, allowing custom handlers to
+ * be omitted and allowing handlers for types that do not exist in, or could not
+ * be inferred from, the value type. `InferStrictComponents` is strict: it
+ * requires inferred custom handlers and rejects unknown ones.
+ */
+export type InferStrictComponents<T> = PortableTextInferStrictComponents<StegaAware<T>>

--- a/packages/next-sanity/test/portableText.stega-types.test.tsx
+++ b/packages/next-sanity/test/portableText.stega-types.test.tsx
@@ -1,8 +1,3 @@
-import type {ComponentProps} from 'react'
-import {describe, expectTypeOf, test} from 'vitest'
-
-import type {DefinedFetchType} from '#live/types'
-
 import type {
   InferComponents,
   InferStrictComponents,
@@ -13,6 +8,10 @@ import type {
   StegaString,
 } from 'next-sanity'
 import {PortableText, stegaClean} from 'next-sanity'
+import type {ComponentProps} from 'react'
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {DefinedFetchType} from '#live/types'
 
 /**
  * Mirrors the phantom marker `sanity typegen` puts on dereferenced references.
@@ -127,7 +126,13 @@ const components = {
       return <figure data-caption={value.caption}>{value.alt}</figure>
     },
     timeline: ({value}) => {
-      return <div>{value.items?.map((item) => <div key={item._key}>{item.title}</div>)}</div>
+      return (
+        <div>
+          {value.items?.map((item) => (
+            <div key={item._key}>{item.title}</div>
+          ))}
+        </div>
+      )
     },
     callout: ({value}) => {
       // literal unions that may be stega encoded must be cleaned before comparing

--- a/packages/next-sanity/test/portableText.stega-types.test.tsx
+++ b/packages/next-sanity/test/portableText.stega-types.test.tsx
@@ -181,6 +181,11 @@ describe('stega-aware InferValue', () => {
     expectTypeOf<CleanBody[number]>().toExtend<PortableTextValue[number]>()
     expectTypeOf<BrandedBody[number]>().toExtend<PortableTextValue[number]>()
 
+    // `InferValue` normalizes in both directions: fed an already-branded
+    // result type it still accepts clean data, and vice versa
+    expectTypeOf<CleanBody>().toExtend<InferValue<StegaBranded<PageQueryResult>>>()
+    expectTypeOf<BrandedBody>().toExtend<InferValue<StegaBranded<PageQueryResult>>>()
+
     // but not arbitrary values
     expectTypeOf<string[]>().not.toExtend<PortableTextValue>()
     expectTypeOf<Array<{_type: 'callout'}>>().not.toExtend<PortableTextValue>()

--- a/packages/next-sanity/test/portableText.stega-types.test.tsx
+++ b/packages/next-sanity/test/portableText.stega-types.test.tsx
@@ -1,0 +1,254 @@
+import type {ComponentProps} from 'react'
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {DefinedFetchType} from '#live/types'
+
+import type {
+  InferComponents,
+  InferStrictComponents,
+  InferValue,
+  SanityQueries,
+  StegaBranded,
+  StegaCleaned,
+  StegaString,
+} from 'next-sanity'
+import {PortableText, stegaClean} from 'next-sanity'
+
+/**
+ * Mirrors the phantom marker `sanity typegen` puts on dereferenced references.
+ * It only exists in the type system, never in the JSON returned by Content Lake.
+ */
+declare const internalGroqTypeReferenceTo: unique symbol
+
+type SanityImageAssetReference = {
+  _ref: string
+  _type: 'reference'
+  _weak?: boolean
+  [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+}
+
+/**
+ * Shapes below mirror what `sanity typegen` generates for the
+ * portable text fields in the `template-nextjs-personal-website` template.
+ */
+type TimelineItem = {
+  title?: string
+  milestones?: Array<{
+    _key: string
+    _type: 'milestone'
+    title?: string
+    description?: string
+    image?: {
+      asset?: SanityImageAssetReference
+      media?: unknown
+      _type: 'image'
+    }
+    tags?: Array<string>
+  }>
+  _type: 'item'
+  _key: string
+}
+
+type PageBodyBlock = {
+  children?: Array<{
+    marks?: Array<string>
+    text?: string
+    _type: 'span'
+    _key: string
+  }>
+  style?: 'normal'
+  listItem?: 'bullet' | 'number'
+  markDefs?: Array<{
+    href?: string
+    _type: 'link'
+    _key: string
+  }>
+  level?: number
+  _type: 'block'
+  _key: string
+}
+
+type PageQueryResult = {
+  _id: string
+  _type: 'page'
+  body: Array<
+    | {_key: string; _type: 'timeline'; items?: Array<TimelineItem>}
+    | PageBodyBlock
+    | {
+        asset?: SanityImageAssetReference
+        media?: unknown
+        caption?: string
+        alt?: string
+        _type: 'image'
+        _key: string
+      }
+    | {
+        _key: string
+        _type: 'callout'
+        tone?: 'positive' | 'critical'
+        heading?: string
+      }
+  > | null
+  title: string | null
+} | null
+
+declare module '@sanity/client' {
+  interface SanityQueries {
+    '*[_type == "page" && slug.current == $slug][0]{_id,_type,body,title}': PageQueryResult
+  }
+}
+
+const pageQuery = '*[_type == "page" && slug.current == $slug][0]{_id,_type,body,title}' as const
+
+// Type-only bindings — erased at runtime; nested samples below are never called.
+declare const sanityFetch: DefinedFetchType
+
+type PortableTextValue = InferValue<SanityQueries[keyof SanityQueries]>
+
+/**
+ * Mirrors `<CustomPortableText>` in `template-nextjs-personal-website`:
+ * a re-usable wrapper typed against every registered query.
+ */
+const components = {
+  block: {
+    normal: ({children}) => <p>{children}</p>,
+  },
+  marks: {
+    link: ({children, value}) => {
+      // `markDefs` on blocks are never stega encoded, `href` stays a plain string
+      if (!value?.href) return children
+      expectTypeOf(value.href).toEqualTypeOf<string>()
+      return <a href={value.href}>{children}</a>
+    },
+  },
+  types: {
+    image: ({value}) => {
+      // branded strings stay assignable to `string`, rendering keeps working
+      return <figure data-caption={value.caption}>{value.alt}</figure>
+    },
+    timeline: ({value}) => {
+      return <div>{value.items?.map((item) => <div key={item._key}>{item.title}</div>)}</div>
+    },
+    callout: ({value}) => {
+      // literal unions that may be stega encoded must be cleaned before comparing
+      const tone = stegaClean(value.tone)
+      expectTypeOf(tone).toEqualTypeOf<'positive' | 'critical' | undefined>()
+      return <aside data-critical={tone === 'critical'}>{value.heading}</aside>
+    },
+  },
+} satisfies InferStrictComponents<PortableTextValue>
+
+function CustomPortableText({value}: {value: PortableTextValue}) {
+  return <PortableText components={components} value={value} />
+}
+
+describe('stega-aware InferValue', () => {
+  test('accepts stega branded sanityFetch data without stegaClean', () => {
+    async function Sample() {
+      const {data} = await sanityFetch({query: pageQuery, stega: true})
+      return Array.isArray(data?.body) && <CustomPortableText value={data.body} />
+    }
+    void Sample
+  })
+
+  test('accepts clean sanityFetch data when stega is disabled', () => {
+    async function Sample() {
+      const {data} = await sanityFetch({query: pageQuery, stega: false})
+      return Array.isArray(data?.body) && <CustomPortableText value={data.body} />
+    }
+    void Sample
+  })
+
+  test('accepts data when stega is a non-literal boolean', () => {
+    async function Sample(stega: boolean) {
+      const {data} = await sanityFetch({query: pageQuery, stega})
+      return Array.isArray(data?.body) && <CustomPortableText value={data.body} />
+    }
+    void Sample
+  })
+
+  test('both clean and branded portable text items are covered', () => {
+    type CleanBody = Exclude<NonNullable<PageQueryResult>['body'], null>
+    type BrandedBody = Exclude<NonNullable<StegaBranded<PageQueryResult>>['body'], null>
+
+    expectTypeOf<CleanBody>().toExtend<PortableTextValue>()
+    expectTypeOf<BrandedBody>().toExtend<PortableTextValue>()
+    expectTypeOf<CleanBody[number]>().toExtend<PortableTextValue[number]>()
+    expectTypeOf<BrandedBody[number]>().toExtend<PortableTextValue[number]>()
+
+    // but not arbitrary values
+    expectTypeOf<string[]>().not.toExtend<PortableTextValue>()
+    expectTypeOf<Array<{_type: 'callout'}>>().not.toExtend<PortableTextValue>()
+  })
+})
+
+describe('stega-aware InferStrictComponents', () => {
+  type StrictComponents = InferStrictComponents<PortableTextValue>
+
+  test('handler values keep the stega brand until cleaned', () => {
+    type CalloutProps = ComponentProps<NonNullable<StrictComponents['types']['callout']>>
+    type Tone = CalloutProps['value']['tone']
+
+    // the branded variant is part of the union, so the value is not safe to
+    // compare against literals until it's been cleaned with `stegaClean`
+    expectTypeOf<Tone>().not.toEqualTypeOf<'positive' | 'critical' | undefined>()
+    expectTypeOf<StegaString<'positive'>>().toExtend<Tone>()
+    expectTypeOf<StegaCleaned<Tone>>().toEqualTypeOf<'positive' | 'critical' | undefined>()
+  })
+
+  test('still requires handlers for custom types', () => {
+    // @ts-expect-error -- image, timeline and callout handlers are required
+    const incomplete = {types: {}} satisfies StrictComponents
+    void incomplete
+  })
+
+  test('still rejects handlers for unknown types', () => {
+    const excess = {
+      types: {
+        image: () => null,
+        timeline: () => null,
+        callout: () => null,
+        // @ts-expect-error -- "unknown" is not a type that appears in the value
+        unknown: () => null,
+      },
+    } satisfies StrictComponents
+    void excess
+  })
+})
+
+describe('stega-aware InferComponents', () => {
+  async function fetchBrandedPage() {
+    return sanityFetch({query: pageQuery, stega: true})
+  }
+  type BrandedPageData = Awaited<ReturnType<typeof fetchBrandedPage>>['data']
+
+  // the forgiving variant allows omitting handlers, and infers directly from
+  // the branded `data` returned by `sanityFetch`
+  const forgivingComponents = {
+    types: {
+      image: ({value}) => <figure>{value.alt}</figure>,
+    },
+  } satisfies InferComponents<NonNullable<BrandedPageData>['body']>
+
+  test('infers from branded sanityFetch data directly', () => {
+    async function Sample() {
+      const {data} = await sanityFetch({query: pageQuery, stega: true})
+      return (
+        Array.isArray(data?.body) && (
+          <PortableText components={forgivingComponents} value={data.body} />
+        )
+      )
+    }
+    void Sample
+  })
+})
+
+describe('PortableText', () => {
+  test('renders stega branded values without stegaClean', () => {
+    async function Sample() {
+      const {data} = await sanityFetch({query: pageQuery, stega: true})
+      return Array.isArray(data?.body) && <PortableText value={data.body} />
+    }
+    void Sample
+  })
+})

--- a/packages/next-sanity/test/portableText.stega-types.test.tsx
+++ b/packages/next-sanity/test/portableText.stega-types.test.tsx
@@ -185,6 +185,16 @@ describe('stega-aware InferValue', () => {
     // result type it still accepts clean data, and vice versa
     expectTypeOf<CleanBody>().toExtend<InferValue<StegaBranded<PageQueryResult>>>()
     expectTypeOf<BrandedBody>().toExtend<InferValue<StegaBranded<PageQueryResult>>>()
+  })
+
+  test('branded data assigns to clean-typed props when strings are wide', () => {
+    // Mirrors handing a handler value to a component with TypeGen-typed props,
+    // like `<TimelineSection timelines={value.items} />` in
+    // `template-nextjs-personal-website`. Requires `@sanity/client@7.26.1`,
+    // which keeps symbol-keyed properties (TypeGen's
+    // `internalGroqTypeReferenceTo` reference marker) unbranded.
+    expectTypeOf<StegaBranded<TimelineItem>>().toExtend<TimelineItem>()
+    expectTypeOf<StegaBranded<TimelineItem[]>>().toExtend<TimelineItem[]>()
 
     // but not arbitrary values
     expectTypeOf<string[]>().not.toExtend<PortableTextValue>()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ settings:
 catalogs:
   default:
     '@sanity/client':
-      specifier: ^7.26.0
-      version: 7.26.0
+      specifier: ^7.26.1
+      version: 7.26.1
     '@sanity/image-url':
       specifier: ^2.1.1
       version: 2.1.1
@@ -82,7 +82,7 @@ importers:
         version: link:../../packages/sanity-config
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.0
+        version: 7.26.1
       '@sanity/image-url':
         specifier: 'catalog:'
         version: 2.1.1
@@ -262,17 +262,17 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(react@19.2.8)
       '@sanity/client':
-        specifier: ^7.26.0
-        version: 7.26.0
+        specifier: ^7.26.1
+        version: 7.26.1
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
       '@sanity/preview-url-secret':
         specifier: ^4.1.2
-        version: 4.1.2(@sanity/client@7.26.0)
+        version: 4.1.2(@sanity/client@7.26.1)
       '@sanity/visual-editing':
         specifier: ^5.7.3
-        version: 5.7.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.26.0)(@types/react@19.2.18)(next@16.3.1-canary.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@7.0.2)
+        version: 5.7.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.26.1)(@types/react@19.2.18)(next@16.3.1-canary.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@7.0.2)
       '@sanity/webhook':
         specifier: ^4.0.4
         version: 4.0.4
@@ -2941,8 +2941,8 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@sanity/client@7.26.0':
-    resolution: {integrity: sha512-7GEzTFRY6kWRjHbJYUDEGKPXHVl/XItGpV5LYCLcWMvBlgfujXuAjdp4hJVZqX8F8OtBzIFqdhiSn5Kh5u/V5Q==}
+  '@sanity/client@7.26.1':
+    resolution: {integrity: sha512-3dIjmo/0dgct6m8brCmyDusiYWrk9dQcCtn1e/EwlIoqVpx1xykk1UXFVl3irC2D2O8LTfO0FsGW+QDcHCaDoQ==}
     engines: {node: '>=20'}
 
   '@sanity/codegen@7.0.3':
@@ -9354,7 +9354,7 @@ snapshots:
   '@sanity/assist@6.1.17(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)(sanity@6.9.0-next.45)(styled-components@6.4.4)':
     dependencies:
       '@portabletext/types': 4.0.2
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/color': 3.0.8
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutator': 6.8.0(@types/react@19.2.18)
@@ -9441,7 +9441,7 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@oclif/core': 4.13.3
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       boxen: 8.0.1
       debug: 4.4.3(supports-color@8.1.1)
       empathic: 2.0.1
@@ -9481,13 +9481,13 @@ snapshots:
       '@oclif/plugin-not-found': 3.2.91(@types/node@24.13.3)
       '@sanity/cli-build': 5.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.2)(tsx@4.23.5)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/cli-core': 2.8.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/codegen': 7.0.3(@oclif/core@4.13.3)(@sanity/cli-core@2.8.0)(oxfmt@0.61.0)(react@19.2.8)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.0
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.26.0)(@types/react@19.2.18)
+      '@sanity/import': 6.0.3(@sanity/client@7.26.1)(@types/react@19.2.18)
       '@sanity/migrate': 8.0.1(@types/react@19.2.18)(xstate@5.32.5)
       '@sanity/runtime-cli': 17.4.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.1)(rolldown@1.2.2)(tsx@4.23.5)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/schema': 6.8.0(@types/react@19.2.18)
@@ -9573,7 +9573,7 @@ snapshots:
       - vue-tsc
       - xstate
 
-  '@sanity/client@7.26.0':
+  '@sanity/client@7.26.1':
     dependencies:
       '@sanity/eventsource': 5.0.4
       get-it: 8.8.3
@@ -9678,10 +9678,10 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.4
 
-  '@sanity/import@6.0.3(@sanity/client@7.26.0)(@types/react@19.2.18)':
+  '@sanity/import@6.0.3(@sanity/client@7.26.1)(@types/react@19.2.18)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/generate-help-url': 4.0.0
       '@sanity/mutator': 6.8.0(@types/react@19.2.18)
       debug: 4.4.3(supports-color@8.1.1)
@@ -9723,7 +9723,7 @@ snapshots:
 
   '@sanity/migrate@8.0.1(@types/react@19.2.18)(xstate@5.32.5)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/types': 6.8.0(@types/react@19.2.18)
       '@sanity/util': 6.8.0(@types/react@19.2.18)
@@ -9740,7 +9740,7 @@ snapshots:
   '@sanity/mutate@0.18.1(xstate@5.32.5)':
     dependencies:
       '@isaacs/ttlcache': 2.1.5
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.3
       hotscript: 1.0.13
@@ -9773,25 +9773,25 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.26.0)(@sanity/types@6.8.0)':
+  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.26.1)(@sanity/types@6.8.0)':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.26.0)(@sanity/types@6.8.0)
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.26.1)(@sanity/types@6.8.0)
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.26.0)(@sanity/types@6.9.0-next.45)':
+  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.26.1)(@sanity/types@6.9.0-next.45)':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.26.0)(@sanity/types@6.9.0-next.45)
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.26.1)(@sanity/types@6.9.0-next.45)
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.1.2(@sanity/client@7.26.0)':
+  '@sanity/preview-url-secret@4.1.2(@sanity/client@7.26.1)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/uuid': 3.0.3
 
   '@sanity/prism-groq@1.1.2': {}
@@ -9808,7 +9808,7 @@ snapshots:
       '@sanity/blueprints-parser': 0.4.0
       '@sanity/cli-build': 5.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.2)(tsx@4.23.5)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/cli-core': 2.8.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       adm-zip: 0.6.0
       array-treeify: 0.1.5
       cardinal: 2.1.1
@@ -9887,7 +9887,7 @@ snapshots:
   '@sanity/sdk@2.19.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0)(xstate@5.32.5)':
     dependencies:
       '@sanity/bifur-client': 1.0.0
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/comlink': 4.0.1
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/diff-patch': 6.0.0
@@ -9948,13 +9948,13 @@ snapshots:
 
   '@sanity/types@6.8.0(@types/react@19.2.18)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.18
 
   '@sanity/types@6.9.0-next.45(@types/react@19.2.18)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.18
 
@@ -9980,7 +9980,7 @@ snapshots:
     dependencies:
       '@date-fns/tz': 1.5.0
       '@date-fns/utc': 2.1.1
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/types': 6.8.0(@types/react@19.2.18)
       date-fns: 4.4.0
       rxjs: 7.8.2
@@ -9991,7 +9991,7 @@ snapshots:
     dependencies:
       '@date-fns/tz': 1.5.0
       '@date-fns/utc': 2.1.1
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/types': 6.9.0-next.45(@types/react@19.2.18)
       date-fns: 4.4.0
       rxjs: 7.8.2
@@ -10014,7 +10014,7 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.8)
       '@rexxars/react-split-pane': 1.0.0(react-dom@19.2.8)(react@19.2.8)
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/color': 3.0.8
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/lezer-groq': 1.0.4
@@ -10040,43 +10040,43 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/visual-editing-csm@3.0.13(@sanity/client@7.26.0)(@sanity/types@6.8.0)(typescript@7.0.2)':
+  '@sanity/visual-editing-csm@3.0.13(@sanity/client@7.26.1)(@sanity/types@6.8.0)(typescript@7.0.2)':
     dependencies:
-      '@sanity/client': 7.26.0
-      '@sanity/visual-editing-types': 2.0.12(@sanity/client@7.26.0)(@sanity/types@6.8.0)
+      '@sanity/client': 7.26.1
+      '@sanity/visual-editing-types': 2.0.12(@sanity/client@7.26.1)(@sanity/types@6.8.0)
       valibot: 1.4.2(typescript@7.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.26.0)(@sanity/types@6.8.0)':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.26.1)(@sanity/types@6.8.0)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
     optionalDependencies:
       '@sanity/types': 6.8.0(@types/react@19.2.18)
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.26.0)(@sanity/types@6.9.0-next.45)':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.26.1)(@sanity/types@6.9.0-next.45)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
     optionalDependencies:
       '@sanity/types': 6.9.0-next.45(@types/react@19.2.18)
 
-  '@sanity/visual-editing-types@2.0.12(@sanity/client@7.26.0)(@sanity/types@6.8.0)':
+  '@sanity/visual-editing-types@2.0.12(@sanity/client@7.26.1)(@sanity/types@6.8.0)':
     dependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
     optionalDependencies:
       '@sanity/types': 6.8.0(@types/react@19.2.18)
 
-  '@sanity/visual-editing@5.7.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.26.0)(@types/react@19.2.18)(next@16.3.1-canary.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@7.0.2)':
+  '@sanity/visual-editing@5.7.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.26.1)(@types/react@19.2.18)(next@16.3.1-canary.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@7.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
-      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.26.0)(@sanity/types@6.8.0)
-      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.26.0)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.26.1)(@sanity/types@6.8.0)
+      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.26.1)
       '@sanity/types': 6.8.0(@types/react@19.2.18)
       '@sanity/ui': 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
-      '@sanity/visual-editing-csm': 3.0.13(@sanity/client@7.26.0)(@sanity/types@6.8.0)(typescript@7.0.2)
+      '@sanity/visual-editing-csm': 3.0.13(@sanity/client@7.26.1)(@sanity/types@6.8.0)(typescript@7.0.2)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -10088,7 +10088,7 @@ snapshots:
       styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       next: 16.3.1-canary.0(@babel/core@7.29.7)(@types/node@24.13.3)(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -10137,7 +10137,7 @@ snapshots:
   '@sanity/workbench@0.1.0-alpha.36(@sanity/sdk@2.19.0)(react@19.2.8)(xstate@5.32.5)':
     dependencies:
       '@module-federation/runtime': 2.8.1
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/color': 3.0.8
       '@sanity/sdk': 2.19.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
@@ -12794,7 +12794,7 @@ snapshots:
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
       '@sanity/cli': 7.16.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.2)(typescript@7.0.2)(xstate@5.32.5)
-      '@sanity/client': 7.26.0
+      '@sanity/client': 7.26.1
       '@sanity/color': 3.0.8
       '@sanity/comlink': 4.0.1
       '@sanity/diff': 6.9.0-next.45
@@ -12811,8 +12811,8 @@ snapshots:
       '@sanity/migrate': 8.0.1(@types/react@19.2.18)(xstate@5.32.5)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/mutator': 6.9.0-next.45(@types/react@19.2.18)
-      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.26.0)(@sanity/types@6.9.0-next.45)
-      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.26.0)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.26.1)(@sanity/types@6.9.0-next.45)
+      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.26.1)
       '@sanity/prism-groq': 1.1.2
       '@sanity/schema': 6.9.0-next.45(@types/react@19.2.18)
       '@sanity/telemetry': 1.1.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@next/env': 16.3.1-canary.0
-  '@sanity/client': ^7.26.0
+  '@sanity/client': ^7.26.1
   '@sanity/image-url': ^2.1.1
   '@sanity/themer': ^0.2.1
   '@sanity/tsconfig': ^2.2.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Upgrading [`template-nextjs-personal-website`](https://github.com/sanity-io/template-nextjs-personal-website) to `next-sanity@13.3.0` and running `npm i && npm run type-check` fails with type errors on `<CustomPortableText>`.

Since [#3860](https://github.com/sanity-io/next-sanity/pull/3860), `sanityFetch` brands `data` with the stega string types from `@sanity/client/stega`. But the `InferValue`, `InferComponents` and `InferStrictComponents` types re-exported from the main entry only understood clean TypeGen shapes, so passing branded data to a wrapper typed with `InferValue<SanityQueries[keyof SanityQueries]>` was a compile error. The error trail pushes people toward `value={stegaClean(props.value)}`, which strips the hidden characters `@sanity/visual-editing` needs to make each paragraph clickable in Visual Editing.

## Fix 1: stega-aware `Infer*` types

The main entry now shadows the three `Infer*` types from `@portabletext/react` with stega-aware versions (`src/portable-text.ts`):

```ts
type StegaAware<T> = StegaCleaned<T> | StegaBranded<T>

export type InferValue<T> = PortableTextInferValue<StegaAware<T>>
export type InferComponents<T> = PortableTextInferComponents<StegaAware<T>>
export type InferStrictComponents<T> = PortableTextInferStrictComponents<StegaAware<T>>
```

Widening to the clean/branded union means:

- `value: InferValue<…>` accepts data from any `sanityFetch` call — `stega: true` (branded), `stega: false` (clean), or a non-literal `boolean` — no wholesale `stegaClean` needed, so stega encoding stays intact for Visual Editing.
- Component handler props keep the branded members: rendering works as-is (branded strings stay assignable to `string`), and literal-union fields still require `stegaClean` on the leaf value before comparing (`stegaClean(value.tone) === 'critical'`).
- `InferStrictComponents` strictness is unchanged: custom-type handlers are still required, unknown handlers still rejected (`_type` keys are never branded, so the inferred handler names dedupe across the clean/branded variants).
- `InferValue` normalizes in both directions, so feeding it an already-branded `typeof data` still accepts clean data too.

`<PortableText>` itself already accepts branded values natively (blocks keep `_type`/`style`/`listItem`/`markDefs` unbranded, and branded spans stay assignable to `PortableTextBlock`), which the new tests lock in.

## Fix 2: bump `@sanity/client` to `^7.26.1`

The other half of the template failure was upstream: `StegaBranded` branded **symbol-keyed** properties, so TypeGen's phantom reference marker `[internalGroqTypeReferenceTo]?: 'sanity.imageAsset'` became `StegaString<'sanity.imageAsset'>` and stopped matching clean-typed props (`<Navbar data={data} />`, `<TimelineSection timelines={items} />`) — even though symbol keys can never exist in the JSON returned by Content Lake.

That's fixed in `@sanity/client@7.26.1` ([sanity-io/client#1242](https://github.com/sanity-io/client/pull/1242)), and this PR bumps the dependency, peer dependency and workspace catalog to `^7.26.1` so both fixes land in one release. A new type test pins the behavior from the consumer side: `StegaBranded<TimelineItem>` is assignable to `TimelineItem` when all real string fields are wide.

## Verification

Verified end-to-end against the actual template by installing a packed tarball of this branch together with the published `@sanity/client@7.26.1`:

- `npm run type-check` exits 0 with **zero template changes**.
- Repo checks pass: `pnpm lint` (type-aware, validates the new type tests and `@ts-expect-error` markers), `pnpm --filter next-sanity test` (171 tests), `pnpm build` with publint, `pnpm knip`. The emitted `dist/index.d.ts` keeps the shadowing (explicit type exports take precedence over `export * from '@portabletext/react'`), confirmed end-to-end via the tarball install. (`apps/mvp` `typegen` fails identically on `main` in this environment — unrelated.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bf4fc9c-ea88-4710-b6c1-76a26d0c9ccb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bf4fc9c-ea88-4710-b6c1-76a26d0c9ccb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

