### PR TITLE
docs(agents): add Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,29 @@ The three condition files must expose the same public surface, but their runtime
 - `next-js` is the implementation used by Next.js when `cacheComponents: true` is enabled.
 
 When adding, removing, or changing an export from `next-sanity/live`, update all three condition entry points together, verify their exported names match exactly, and preserve the condition-specific runtime behavior.
+
+## Cursor Cloud specific instructions
+
+This is a pnpm + Turborepo monorepo. The publishable library is `packages/next-sanity`; `apps/mvp` (port 3000) and `apps/static` (port 3001) are Next.js demo apps, and `fixtures/*/*` are CI build guardrails. Standard commands live in the root `package.json` scripts (`build`, `dev`, `lint`, `test`, `test:e2e`) and per-app `package.json`; use those rather than duplicating them here.
+
+### Node version gotcha (important)
+
+`pnpm build` compiles `packages/next-sanity` with `tsdown`, which loads its `.ts` config using Node's native TypeScript stripping (`process.features.typescript`). That requires Node >= 22.18 (or 24). The VM's default `node` (`/exec-daemon/node`, currently v22.14) lacks it, so tsdown falls back to the `unrun` config loader, which is not installed, and the build fails with `Failed to import module "unrun"`.
+
+Use the pre-installed nvm Node (v22.22.2) for any build/dev/test work by prepending it to `PATH`:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+```
+
+`nvm use` alone is not enough because `/exec-daemon` sits ahead of nvm's shims in `PATH`. This nvm node also bundles the correct `pnpm` (10.34.5), so prepending it fixes both `node` and `pnpm` in one step. `pnpm install` itself works on the default node; only building/running needs the newer node. `pnpm test:e2e` (Vitest browser project) needs Chromium: `pnpm playwright install chromium`.
+
+### Demo app env
+
+`apps/mvp` and `apps/static` need a gitignored `.env.local` with `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET` (see each app's `.env.local.example`). The example project `pv8y60vp/production` is publicly readable, so published content renders without a token. `SANITY_API_READ_TOKEN` is only required for draft mode, Presentation/visual-editing preview, and authenticated live queries — not for basic rendering.
+
+### Dev/runtime notes
+
+- Run a single app instead of `pnpm dev` (which starts the library watcher plus both apps): `pnpm --filter mvp dev` or `pnpm --filter static dev`.
+- `apps/mvp` runs Next.js 16 with Cache Components (`cacheComponents: true`) and the React Compiler. `next dev` auto-generates `apps/mvp/AGENTS.md` and `apps/mvp/CLAUDE.md` — these are generated artifacts, do not commit them.
+- In dev, CMS content edits are reflected on the next page reload.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the `next-sanity` monorepo so Cursor Cloud agents can build, lint, test, and run the demo apps. The only source change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing durable, non-obvious setup gotchas.

## What was verified

All commands run with the pre-installed nvm Node `v22.22.2` (see the Node gotcha below):

| Task | Command | Result |
| --- | --- | --- |
| Install | `pnpm install` | ✅ 1128 packages |
| Build library | `pnpm build` | ✅ `next-sanity` built via `tsdown` |
| Lint | `pnpm lint` | ✅ oxlint clean |
| Unit tests | `pnpm --filter next-sanity exec vitest run --project unit` | ✅ 161 passed, 12 skipped |
| Browser e2e | `pnpm test:e2e` (after `pnpm playwright install chromium`) | ✅ 21 passed |
| Full test suite | `pnpm test` | ✅ 4/4 turbo tasks (incl. pass/fail fixtures) |
| Run app | `pnpm --filter mvp dev` (port 3000) | ✅ renders live Sanity content |

## Key finding: Node version gotcha

`pnpm build` uses `tsdown`, which loads its `.ts` config via Node's native TypeScript stripping (Node >= 22.18/24). The VM's default `node` (`/exec-daemon/node`, v22.14) lacks it and tsdown falls back to the uninstalled `unrun` loader, breaking the build. Fix (documented in `AGENTS.md`): prepend the pre-installed nvm Node to `PATH` (which also provides the correct pnpm):

```bash
export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
```

`pnpm install` (the update script) works on the default node; only build/dev/test need the newer node.

## Hello-world demonstration

Pointed the `mvp` app at a public Sanity dataset, created a `post` via the Content Lake API, and confirmed the running Next.js app renders it. Editing the post title in the CMS and reloading updates the rendered page — demonstrating the core `next-sanity` content pipeline end-to-end. Demo data was cleaned up and the env restored to the canonical example project `pv8y60vp/production`.

[next_sanity_mvp_content_update_demo.mp4](https://cursor.com/agents/bc-109b3a1f-4564-476c-8018-92e14cb5b203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnext_sanity_mvp_content_update_demo.mp4)

[Homepage rendering the CMS-created post](https://cursor.com/agents/bc-109b3a1f-4564-476c-8018-92e14cb5b203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmvp_homepage_created_post.webp)
[Homepage after editing the post in the CMS](https://cursor.com/agents/bc-109b3a1f-4564-476c-8018-92e14cb5b203/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmvp_homepage_updated_post.webp)

## Notes

- The `mvp`/`static` `.env.local` files are gitignored; the example project is publicly readable so no token is needed to render published content.
- `next dev` auto-generates `apps/mvp/AGENTS.md` and `apps/mvp/CLAUDE.md` — left untracked as generated artifacts.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-109b3a1f-4564-476c-8018-92e14cb5b203?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-109b3a1f-4564-476c-8018-92e14cb5b203&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

