### PR TITLE
feat(ailf): add sync-tag-invalidate-function eval task

### DIFF
--- a/packages/ailf/.ailf/tasks/setup-sync-tag-invalidate-function.reference.tsx
+++ b/packages/ailf/.ailf/tasks/setup-sync-tag-invalidate-function.reference.tsx
@@ -1,0 +1,124 @@
+// Guarantee fresh content for every visitor by invalidating the Next.js cache
+// server-side whenever published content changes, and by holding live events
+// back until that invalidation has completed.
+//
+// The flow: publishing a change makes Content Lake emit sync tags for the
+// affected queries. A Sync Tag Invalidate Function — deployed to Sanity's
+// infrastructure with Blueprints — receives them, POSTs them to the app's
+// `/api/revalidate-tags` endpoint (which expires the matching `sanity:`-prefixed
+// cache tags registered by `sanityFetch`), and then calls `done()`. Calling
+// `done()` is what releases the held-back live events to browsers connected
+// with `waitFor="function"`, so an open tab's refresh always hits an
+// already-invalidated cache. Because invalidation runs with no browser
+// involved, content also becomes fresh when nobody has the site open.
+//
+// Setup commands (run in `studio/`):
+//   npx sanity blueprints init . --type ts --stack-name production --project-id xxxxxxxx
+//   npx sanity functions add --name cache-invalidate --type sync-tag-invalidate
+//   npx sanity blueprints deploy
+//
+// `sanity/live.ts` and `app/page.tsx` are unchanged.
+
+// --- studio/sanity.blueprint.ts ---
+import {defineBlueprint, defineSyncTagInvalidateFunction} from '@sanity/blueprints'
+
+export default defineBlueprint({
+  resources: [
+    defineSyncTagInvalidateFunction({
+      name: 'cache-invalidate',
+      // Scope to the one dataset the app reads from: multiple
+      // sync-tag-invalidate functions on a dataset risk race conditions.
+      event: {resource: {type: 'dataset', id: 'xxxxxxxx.production'}},
+      // Resolved from the deploying machine's environment at deploy time.
+      // Alternatively: npx sanity functions env add cache-invalidate SANITY_REVALIDATE_TAGS_SECRET <value>
+      env: {SANITY_REVALIDATE_TAGS_SECRET: process.env.SANITY_REVALIDATE_TAGS_SECRET!},
+    }),
+  ],
+})
+
+// --- studio/functions/cache-invalidate/index.ts ---
+import {syncTagInvalidateEventHandler} from '@sanity/functions'
+
+const REVALIDATE_URL = 'https://acme-blog.example.com/api/revalidate-tags'
+
+export const handler = syncTagInvalidateEventHandler(async ({event, done}) => {
+  const {syncTags} = event.data
+
+  // Expire the Next.js cache entries that depend on these tags first…
+  const res = await fetch(REVALIDATE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.SANITY_REVALIDATE_TAGS_SECRET}`,
+    },
+    body: JSON.stringify({tags: syncTags}),
+  })
+  console.log(`Revalidated ${syncTags.length} tags, HTTP ${res.status}`)
+
+  // …then notify Sanity. `done()` releases the events held back for
+  // `<SanityLive waitFor="function">` connections, so it must only run after
+  // the cache is invalidated — and it must complete, or those clients never
+  // receive the change. Confirm it succeeded and log failures.
+  try {
+    const response = await done(syncTags)
+    console.log('Invalidation complete, Sanity responded with HTTP', response.status)
+  } catch (err) {
+    console.error('Error invoking the Sanity invalidation done endpoint!', err)
+  }
+})
+
+// --- app/api/revalidate-tags/route.ts ---
+import {revalidateTag} from 'next/cache'
+import {timingSafeEqual} from 'node:crypto'
+
+export async function POST(request: Request) {
+  const expectedSecret = process.env.SANITY_REVALIDATE_TAGS_SECRET
+  if (!expectedSecret) {
+    return Response.json({error: 'Server configuration error'}, {status: 500})
+  }
+
+  const secret = request.headers.get('authorization')?.replace(/^Bearer /, '') ?? ''
+  const expectedSecretBuffer = Buffer.from(expectedSecret)
+  const secretBuffer = Buffer.from(secret)
+  if (
+    expectedSecretBuffer.length !== secretBuffer.length ||
+    !timingSafeEqual(expectedSecretBuffer, secretBuffer)
+  ) {
+    return Response.json({error: 'Unauthorized'}, {status: 401})
+  }
+
+  const {tags} = (await request.json()) as {tags?: unknown}
+  if (!Array.isArray(tags) || !tags.every((tag) => typeof tag === 'string')) {
+    return Response.json({error: '`tags` must be an array of strings'}, {status: 400})
+  }
+
+  for (const tag of tags) {
+    // `sanityFetch` from `defineLive` prefixes its cache tags with `sanity:`,
+    // so the raw sync tags need the same prefix here. `{expire: 0}` expires
+    // immediately instead of stale-while-revalidate, so the refresh triggered
+    // after `done()` — and the next visit from anyone else — is guaranteed
+    // to serve fresh content.
+    revalidateTag(`sanity:${tag}`, {expire: 0})
+  }
+
+  return Response.json({revalidated: tags})
+}
+
+// --- app/layout.tsx ---
+import {SanityLive} from '@/sanity/live'
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        {/* The deployed function only invalidates the production deployment's
+            cache, so only production connections should wait for it. With
+            `waitFor="function"` the default action becomes a plain client-side
+            refresh — the function already revalidated server-side. Local dev
+            and previews keep immediate events and default revalidation. */}
+        <SanityLive waitFor={process.env.VERCEL_ENV === 'production' ? 'function' : undefined} />
+      </body>
+    </html>
+  )
+}

--- a/packages/ailf/.ailf/tasks/setup-sync-tag-invalidate-function.task.ts
+++ b/packages/ailf/.ailf/tasks/setup-sync-tag-invalidate-function.task.ts
@@ -1,0 +1,160 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'setup-sync-tag-invalidate-function',
+  title: 'Set up a Sync Tag Invalidate Function for guaranteed cache invalidation',
+  area: 'next-sanity',
+  context: {
+    docs: [
+      {
+        path: 'functions/sync-tag-function-quickstart',
+        reason:
+          'Creating, testing, and deploying a Sync Tag Invalidate Function, and the done() contract behind waitFor',
+      },
+      {
+        path: 'content-lake/live-content-api',
+        reason:
+          'Live Content API concepts: sync tags, and pairing an invalidate function with waitFor on SanityLive',
+      },
+      {
+        path: 'blueprints/blueprint-config',
+        reason: 'Blueprint function configuration: dataset scoping and environment variables',
+      },
+      {
+        path: 'nextjs/caching-and-revalidation-in-nextjs',
+        reason: 'The tag-based revalidation model behind the revalidation endpoint',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/setup-sync-tag-invalidate-function.reference.tsx',
+  prompt: {
+    text: `This Next.js App Router blog uses Sanity Live via next-sanity: visitors with the site open see published changes appear automatically. It deploys to Vercel with production at https://acme-blog.example.com, and the Sanity Studio lives in the same repository under \`studio/\` (project id \`xxxxxxxx\`, dataset \`production\`).
+
+Editors report two freshness gaps. When they publish while nobody has the site open, no browser receives a live event, nothing invalidates the cache, and the next visitor still gets the old page until the cache expires on its own. And even visitors with an open tab are not guaranteed the new content: cached routes revalidate in the background, so a reload right after a publish can still serve the previous version.
+
+Close both gaps with server-side invalidation: whenever published content changes, run code on Sanity's infrastructure that purges the affected cached content through an endpoint in this app, with no browser involved. Connected browsers should not react to a publish until that invalidation has completed, so an open tab never refreshes into a stale cache.
+
+This is the existing application:
+
+\`\`\`ts
+// sanity/live.ts
+import {createClient} from 'next-sanity'
+import {defineLive} from 'next-sanity/live'
+
+export const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: '2024-01-01',
+  useCdn: true,
+})
+
+export const {sanityFetch, SanityLive} = defineLive({client})
+\`\`\`
+
+\`\`\`tsx
+// app/layout.tsx
+import {SanityLive} from '@/sanity/live'
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        <SanityLive />
+      </body>
+    </html>
+  )
+}
+\`\`\`
+
+\`\`\`tsx
+// app/page.tsx
+import Link from 'next/link'
+import {defineQuery} from 'next-sanity'
+
+import {sanityFetch} from '@/sanity/live'
+
+const POSTS_QUERY = defineQuery(\`
+  *[_type == "post" && defined(slug.current)] | order(publishedAt desc){_id, title, slug}
+\`)
+
+export default async function IndexPage() {
+  const {data: posts} = await sanityFetch({query: POSTS_QUERY})
+
+  return (
+    <main>
+      <h1>Blog</h1>
+      <ul>
+        {posts.map((post) => (
+          <li key={post._id}>
+            <Link href={\`/posts/\${post.slug.current}\`}>{post.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+\`\`\`
+
+Show all the files that need to change, and any new files, on both the Next.js and Sanity sides, including how the invalidation code gets deployed.`,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'sync-tag-invalidate-function',
+          text: 'A Sanity Function built with `syncTagInvalidateEventHandler` from `@sanity/functions` reads the invalidated sync tags from `event.data.syncTags` and sends them to a revalidation endpoint in the Next.js app.',
+        },
+        {
+          id: 'blueprint-registration',
+          text: 'The function is registered as a sync-tag-invalidate resource via `defineSyncTagInvalidateFunction` from `@sanity/blueprints` in `sanity.blueprint.ts` (or the equivalent JSON blueprint), deployed with `sanity blueprints deploy`.',
+        },
+        {
+          id: 'revalidate-endpoint',
+          text: 'A route handler in the Next.js app (e.g. `app/api/revalidate-tags/route.ts`) parses the posted tags and expires them with `revalidateTag` from `next/cache`, adding the `sanity:` prefix that `sanityFetch` uses for its cache tags and expiring immediately (`{expire: 0}`) rather than stale-while-revalidate.',
+        },
+        {
+          id: 'done-releases-events',
+          text: 'The function notifies Sanity that invalidation is complete by calling the `done` callback with the sync tags only after calling the revalidation endpoint, since `done` is what releases the held-back live events to waiting browsers.',
+        },
+        {
+          id: 'wait-for-function-prop',
+          text: '`<SanityLive>` is given `waitFor="function"` so live events are delayed until the deployed function has processed them, meaning connected tabs only refresh after the cache has actually been invalidated.',
+        },
+      ],
+    },
+    {
+      type: 'llm-rubric',
+      template: 'code-correctness',
+      criteria: [
+        {
+          id: 'uses-sync-tag-function-apis',
+          text: 'Uses the sync-tag-invalidate primitives (`syncTagInvalidateEventHandler`, `defineSyncTagInvalidateFunction`), not GROQ-powered webhooks, `parseBody` from `next-sanity/webhook`, or a document function that recomputes cache tags by hand.',
+        },
+        {
+          id: 'endpoint-authenticated',
+          text: 'The revalidation endpoint rejects unauthenticated requests using a server-side secret shared with the function (for example a bearer token compared timing-safely), validates that `tags` is an array of strings, and does not hardcode the secret.',
+        },
+        {
+          id: 'wait-for-scoped-to-deployment',
+          text: "The `waitFor` prop is only applied where the deployed function actually invalidates the cache, ideally `waitFor={process.env.VERCEL_ENV === 'production' ? 'function' : undefined}`, so local dev and previews keep immediate events and default revalidation.",
+        },
+        {
+          id: 'keeps-live-integration',
+          text: 'The existing live setup stays intact: `sanityFetch` still powers data fetching and `<SanityLive />` stays rendered; the function complements the live connection rather than being replaced by polling or reintroduced time-based revalidation (`export const revalidate`).',
+        },
+      ],
+    },
+    {type: 'contains', value: 'syncTagInvalidateEventHandler'},
+    {
+      type: 'contains-any',
+      value: ['defineSyncTagInvalidateFunction', 'sanity.function.sync-tag-invalidate'],
+    },
+    {type: 'contains', value: 'waitFor'},
+    {type: 'contains', value: 'revalidateTag'},
+  ],
+})

--- a/packages/ailf/README.md
+++ b/packages/ailf/README.md
@@ -15,14 +15,15 @@ The reference solution is never shown to the evaluated model and does not contri
 
 ## Task inventory
 
-| Task                                                                                               | Probes                                                                               |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [`add-live-to-client-fetch-app`](.ailf/tasks/add-live-to-client-fetch-app.task.ts)                 | Adding Sanity Live to an App Router blog that fetches with plain `@sanity/client`    |
-| [`migrate-live-app-to-cache-components`](.ailf/tasks/migrate-live-app-to-cache-components.task.ts) | Migrating a Sanity Live app from ISR/revalidation to Cache Components with parity    |
-| [`add-live-to-cache-components-app`](.ailf/tasks/add-live-to-cache-components-app.task.ts)         | Adding Sanity Live to an app already on `cacheComponents` with raw client fetches    |
-| [`add-visual-editing-draft-mode`](.ailf/tasks/add-visual-editing-draft-mode.task.ts)               | Draft Mode + Visual Editing (`defineEnableDraftMode`, `VisualEditing`, Presentation) |
-| [`debug-stega-encoding-bugs`](.ailf/tasks/debug-stega-encoding-bugs.task.ts)                       | Diagnosing stega-encoded strings leaking into app logic, fixing with `stegaClean`    |
-| [`setup-typegen-strict-portable-text`](.ailf/tasks/setup-typegen-strict-portable-text.task.ts)     | Sanity TypeGen setup including strict Portable Text inference                        |
+| Task                                                                                               | Probes                                                                                |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [`add-live-to-client-fetch-app`](.ailf/tasks/add-live-to-client-fetch-app.task.ts)                 | Adding Sanity Live to an App Router blog that fetches with plain `@sanity/client`     |
+| [`migrate-live-app-to-cache-components`](.ailf/tasks/migrate-live-app-to-cache-components.task.ts) | Migrating a Sanity Live app from ISR/revalidation to Cache Components with parity     |
+| [`add-live-to-cache-components-app`](.ailf/tasks/add-live-to-cache-components-app.task.ts)         | Adding Sanity Live to an app already on `cacheComponents` with raw client fetches     |
+| [`setup-sync-tag-invalidate-function`](.ailf/tasks/setup-sync-tag-invalidate-function.task.ts)     | Server-side invalidation with a Sync Tag Invalidate Function and `waitFor="function"` |
+| [`add-visual-editing-draft-mode`](.ailf/tasks/add-visual-editing-draft-mode.task.ts)               | Draft Mode + Visual Editing (`defineEnableDraftMode`, `VisualEditing`, Presentation)  |
+| [`debug-stega-encoding-bugs`](.ailf/tasks/debug-stega-encoding-bugs.task.ts)                       | Diagnosing stega-encoded strings leaking into app logic, fixing with `stegaClean`     |
+| [`setup-typegen-strict-portable-text`](.ailf/tasks/setup-typegen-strict-portable-text.task.ts)     | Sanity TypeGen setup including strict Portable Text inference                         |
 
 ## Running locally
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Extends the AILF suite with a task probing whether models can set up guaranteed server-side cache invalidation for a Sanity Live app, modeled on the canonical [lcapi-examples cache-invalidate function](https://github.com/sanity-io/lcapi-examples/blob/ec9bec4b9da39e0f64c5f706f79e0e6709d56794/studio/functions/cache-invalidate/index.ts).

## What the task evals

The prompt frames the two real freshness gaps (nothing invalidates the cache when no browser is connected; connected tabs can refresh into stale-while-revalidate content) and asks for server-side invalidation as an outcome, without naming the APIs. Rubrics and guards then check that the output:

- builds a Sanity Function with `syncTagInvalidateEventHandler` from `@sanity/functions` that reads `event.data.syncTags` and POSTs them to an endpoint in the app
- registers it via `defineSyncTagInvalidateFunction` from `@sanity/blueprints` and deploys with `sanity blueprints deploy`
- implements an authenticated `/api/revalidate-tags` route handler calling `revalidateTag(`sanity:${tag}`, {expire: 0})` (the `sanity:` prefix matching `sanityFetch`'s cache tags)
- calls `done(syncTags)` only after the endpoint call, since `done` releases the held-back events
- sets `waitFor="function"` on `<SanityLive>`, scoped to the production deployment the function actually invalidates

## Details

- `context.docs` reference verified canonical docs: `functions/sync-tag-function-quickstart`, `content-lake/live-content-api`, `blueprints/blueprint-config`, `nextjs/caching-and-revalidation-in-nextjs`
- The reference answer key follows the quickstart + `MIGRATE-v12-to-v13.md` guidance (timing-safe secret check, dataset-scoped blueprint event, conditional `waitFor`), and documents that with `waitFor="function"` the default `action` becomes a client-side refresh
- README task inventory updated (table realigned by oxfmt)

## Validation

- `pnpm --filter @repo/ailf run ailf:validate` — 7 tasks across 7 files, all valid
- `pnpm lint` (type-aware oxlint), `tsc --noEmit` on the ailf package, `pnpm knip`, and repo-wide `oxfmt` all clean
- The `ailf-eval` workflow will run the full remote eval on this PR since it touches `packages/ailf/**`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edd8ddf6-b409-43e0-92d7-887cc3902aa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edd8ddf6-b409-43e0-92d7-887cc3902aa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

