### PR TITLE
fix(deps): upgrade @sanity/client to v8

### DIFF
--- a/.changeset/upgrade-sanity-client-v8.md
+++ b/.changeset/upgrade-sanity-client-v8.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": major
+---
+
+Upgrade `@sanity/client` to v8, which requires Node 22.12+ and drops the `unstable__adapter` and `unstable__environment` exports. `next-sanity` no longer re-exports `unstable__adapter`/`unstable__environment` from `next-sanity`.

--- a/apps/mvp/app/(website)/no-resolve-perspective/page.tsx
+++ b/apps/mvp/app/(website)/no-resolve-perspective/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -39,8 +38,6 @@ export default async function IndexPage() {
       <ContentSourceMapDebug sourceMap={sourceMap} />
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           <PostsLayout data={data} draftMode={isDraftMode} />

--- a/apps/mvp/app/(website)/only-production/page.tsx
+++ b/apps/mvp/app/(website)/only-production/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type DefinedFetchType} from 'next-sanity/live'
 import Link from 'next/link'
 
@@ -27,8 +26,6 @@ export default async function IndexPage() {
       <ContentSourceMapDebug sourceMap={sourceMap} />
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           <PostsLayout data={data} draftMode={false} />

--- a/apps/mvp/app/(website)/only-visual-editing/page.tsx
+++ b/apps/mvp/app/(website)/only-visual-editing/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -55,8 +54,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           {isDraftMode ? (

--- a/apps/mvp/app/(website)/page.tsx
+++ b/apps/mvp/app/(website)/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -57,8 +56,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           {isDraftMode ? (

--- a/apps/mvp/package.json
+++ b/apps/mvp/package.json
@@ -40,6 +40,6 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": "20 || 22 || 24"
+    "node": ">=22.12"
   }
 }

--- a/apps/static/app/page.tsx
+++ b/apps/static/app/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import Link from 'next/link'
 
 import PostsLayout, {type PostsLayoutProps, query} from '@/app/PostsLayout'
@@ -13,8 +12,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="absolute inset-0">
           <div className="h-1/3 bg-white sm:h-2/3" />

--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@portabletext/react": "^7.0.1",
-    "@sanity/client": "^7.26.2",
+    "@sanity/client": "^8.2.0",
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/preview-url-secret": "^4.1.4",
     "@sanity/visual-editing": "^6.0.4",
@@ -123,7 +123,7 @@
     "vitest-package-exports": "^1.2.0"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2",
+    "@sanity/client": "^8.2.0",
     "next": "^16.0.0-0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
@@ -131,7 +131,7 @@
     "styled-components": "^6.1"
   },
   "engines": {
-    "node": ">=20.19 <22 || >=22.12"
+    "node": ">=22.12"
   },
   "msw": {
     "workerDirectory": [

--- a/packages/next-sanity/src/__tests__/exports.spec.ts
+++ b/packages/next-sanity/src/__tests__/exports.spec.ts
@@ -29,8 +29,6 @@ test(`exports snapshot for the ${JSON.stringify(env)} condition`, {timeout: 15_0
         stegaBrand: function
         stegaClean: function
         toPlainText: function
-        unstable__adapter: string
-        unstable__environment: string
         variantsApiVersion: string
       ./draft-mode:
         defineEnableDraftMode: function

--- a/packages/next-sanity/src/client.ts
+++ b/packages/next-sanity/src/client.ts
@@ -1,5 +1,5 @@
 export type * from '@sanity/client'
-export {createClient, unstable__adapter, unstable__environment} from '@sanity/client'
+export {createClient} from '@sanity/client'
 export {
   stegaBrand,
   stegaClean,

--- a/packages/next-sanity/test/SanityLive.test.tsx
+++ b/packages/next-sanity/test/SanityLive.test.tsx
@@ -1,8 +1,7 @@
-import {createClient} from 'next-sanity'
 import {SanityLive as SanityLiveClientComponent} from 'next-sanity/live/client-components'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
-import {apiVersion, dataset, projectId, renderToString} from './helpers'
+import {apiVersion, createClient, dataset, projectId, renderToString} from './helpers'
 
 let isDraftMode = false
 let isDraftModeCalled = false

--- a/packages/next-sanity/test/helpers.ts
+++ b/packages/next-sanity/test/helpers.ts
@@ -1,7 +1,23 @@
-import type {QueryParams} from '@sanity/client'
+import type {ClientConfig, QueryParams} from '@sanity/client'
+import {createClient as createSanityClient} from 'next-sanity'
 import {prerender} from 'react-dom/static'
 
 import type {LivePerspective} from '#live/types'
+
+/**
+ * `@sanity/client` v8 (via get-it v9) resolves its own undici-backed fetch in
+ * Node instead of calling `globalThis.fetch`, so MSW (which only patches the
+ * global) can no longer intercept requests made through a plain
+ * `createClient()`. Route requests back through the global via the client's
+ * internal `resolveFetch` escape hatch — the same one its own test suite uses
+ * to inject `get-it/mock`.
+ */
+export function createClient(config: ClientConfig) {
+  return createSanityClient({
+    ...config,
+    resolveFetch: () => fetch,
+  })
+}
 
 export const projectId = 'pv8y60vp'
 export const dataset = 'production'

--- a/packages/next-sanity/test/sanityFetch.test.ts
+++ b/packages/next-sanity/test/sanityFetch.test.ts
@@ -1,12 +1,11 @@
 import {perspectiveCookieName, variantCookieName} from '@sanity/preview-url-secret/constants'
 import {vercelStegaDecodeAll} from '@vercel/stega'
-import {createClient} from 'next-sanity'
 import {PHASE_PRODUCTION_BUILD} from 'next/constants'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import type {LivePerspective} from '#live/types'
 
-import {apiVersion, dataset, getSanityFetchMock, projectId} from './helpers'
+import {apiVersion, createClient, dataset, getSanityFetchMock, projectId} from './helpers'
 
 let isDraftMode = false
 let isDraftModeCalled = false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ settings:
 catalogs:
   default:
     '@sanity/client':
-      specifier: ^7.26.2
-      version: 7.26.2
+      specifier: ^8.2.0
+      version: 8.2.0
     '@sanity/image-url':
       specifier: ^2.1.1
       version: 2.1.1
@@ -82,7 +82,7 @@ importers:
         version: link:../../packages/sanity-config
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.2.0(vitest@4.1.10)
       '@sanity/image-url':
         specifier: 'catalog:'
         version: 2.1.1
@@ -271,17 +271,17 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(react@19.2.8)
       '@sanity/client':
-        specifier: ^7.26.2
-        version: 7.26.2
+        specifier: ^8.2.0
+        version: 8.2.0(vitest@4.1.10)
       '@sanity/generate-help-url':
         specifier: ^4.0.0
         version: 4.0.0
       '@sanity/preview-url-secret':
         specifier: ^4.1.4
-        version: 4.1.4(@sanity/client@7.26.2)
+        version: 4.1.4(@sanity/client@8.2.0)
       '@sanity/visual-editing':
         specifier: ^6.0.4
-        version: 6.0.4(@sanity/client@7.26.2)(@types/react@19.2.18)(next@16.3.1-canary.15)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.2)(typescript@7.0.2)
+        version: 6.0.4(@sanity/client@8.2.0)(@types/react@19.2.18)(next@16.3.1-canary.15)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.2)(typescript@7.0.2)
       '@sanity/webhook':
         specifier: ^4.0.4
         version: 4.0.4
@@ -4000,6 +4000,10 @@ packages:
     resolution: {integrity: sha512-iEkGiHbrxCnT/A30A6pH+vX4otP3lLp935Vwuv0/YrnETxrKCn6PnsZU+TfTm6ZEZ9kZGs8wKP5yBLmZw5S6OQ==}
     engines: {node: '>=20'}
 
+  '@sanity/client@8.2.0':
+    resolution: {integrity: sha512-SK2o8uh9ayAYAHJtKvd3r78Y5QHlV6RA1H249rYXtm71rdvp4dVvQyf3E/QtYVaeIhrWufK1Mh7sbX6FDVLtWQ==}
+    engines: {node: '>=22.12.0'}
+
   '@sanity/codegen@7.0.3':
     resolution: {integrity: sha512-t3Svo28RWX7OOvj4DkNX0fSWpzt+94pslKwvkKhSs4Lw24Ta1hYkE1a+OgwUjKBbw2Za54V7NpMwNlXjPEr2Fw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -6311,6 +6315,10 @@ packages:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@4.0.0:
+    resolution: {integrity: sha512-aIpvYxbqTx4KYWw73KpCt1Rh22tEAJ144F1qR76CT3Ex+LNMEPKf5HFrK5Yz9fMP1EVT0GrfA35VZvWQhMPuSQ==}
+    engines: {node: '>=22.12'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
@@ -6322,6 +6330,10 @@ packages:
   eventsource@4.1.1:
     resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
     engines: {node: '>=20.0.0'}
+
+  eventsource@5.1.0:
+    resolution: {integrity: sha512-+errgX9LYbcpibagHh7CEjEZJvQbIDZB2yY7SbUAhHGv4Ircri3T9LH33TUtcXHDy/pFYel1xCi4VOcBnr3wmw==}
+    engines: {node: '>=22.12.0'}
 
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
@@ -6614,6 +6626,15 @@ packages:
   get-it@8.8.3:
     resolution: {integrity: sha512-IfkbWqOGO2kd2Ccgiz/NIzk3bcwjtVqBm3RNa3j/veHg2q7c1DgS3EXrCrvIWH0jbNTbhkdblnxBP7Dm8CiH+A==}
     engines: {node: '>=14.0.0'}
+
+  get-it@9.5.1:
+    resolution: {integrity: sha512-XCVgepH7ROA/VEW4iaorxII3ZqQt7bqNhRNdeOklqwWsl7iGuJCGL7jxkUzcWVpK5zsYr0WaMqeXrIfeL02Uig==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   get-latest-version@6.0.1:
     resolution: {integrity: sha512-6Zub9FhioDbCJzGTZtetVvAkLeA5UnvQEbKfFZUc62hcZm3gO3Txr21oRGOcT6SdiKhjI0vWd/Jxct+wuLJgHA==}
@@ -14084,6 +14105,16 @@ snapshots:
       nanoid: 3.3.18
       rxjs: 7.8.2
 
+  '@sanity/client@8.2.0(vitest@4.1.10)':
+    dependencies:
+      eventsource: 5.1.0
+      get-it: 9.5.1(vitest@4.1.10)
+      nanoid: 6.0.1
+      obug: 2.1.4
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - vitest
+
   '@sanity/codegen@7.0.3(@oclif/core@4.13.3)(@sanity/cli-core@2.8.1)(oxfmt@0.63.0)(react@19.2.8)':
     dependencies:
       '@babel/core': 7.29.7
@@ -14298,6 +14329,11 @@ snapshots:
   '@sanity/preview-url-secret@4.1.4(@sanity/client@7.26.2)':
     dependencies:
       '@sanity/client': 7.26.2
+      '@sanity/uuid': 3.0.3
+
+  '@sanity/preview-url-secret@4.1.4(@sanity/client@8.2.0)':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.10)
       '@sanity/uuid': 3.0.3
 
   '@sanity/prism-groq@1.1.2': {}
@@ -14584,10 +14620,10 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/visual-editing-csm@3.0.15(@sanity/client@7.26.2)(@sanity/types@6.9.2)(typescript@7.0.2)':
+  '@sanity/visual-editing-csm@3.0.15(@sanity/client@8.2.0)(@sanity/types@6.9.2)(typescript@7.0.2)':
     dependencies:
-      '@sanity/client': 7.26.2
-      '@sanity/visual-editing-types': 2.0.14(@sanity/client@7.26.2)(@sanity/types@6.9.2)
+      '@sanity/client': 8.2.0(vitest@4.1.10)
+      '@sanity/visual-editing-types': 2.0.14(@sanity/client@8.2.0)(@sanity/types@6.9.2)
       valibot: 1.4.2(typescript@7.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
@@ -14605,16 +14641,22 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.9.2(@types/react@19.2.18)
 
-  '@sanity/visual-editing@6.0.4(@sanity/client@7.26.2)(@types/react@19.2.18)(next@16.3.1-canary.15)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.2)(typescript@7.0.2)':
+  '@sanity/visual-editing-types@2.0.14(@sanity/client@8.2.0)(@sanity/types@6.9.2)':
+    dependencies:
+      '@sanity/client': 8.2.0(vitest@4.1.10)
+    optionalDependencies:
+      '@sanity/types': 6.9.2(@types/react@19.2.18)
+
+  '@sanity/visual-editing@6.0.4(@sanity/client@8.2.0)(@types/react@19.2.18)(next@16.3.1-canary.15)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.2)(typescript@7.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.3
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/presentation-comlink': 2.2.3(@sanity/types@6.9.2)
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@7.26.2)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0)
       '@sanity/types': 6.9.2(@types/react@19.2.18)
       '@sanity/ui': 4.0.3(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.2)
-      '@sanity/visual-editing-csm': 3.0.15(@sanity/client@7.26.2)(@sanity/types@6.9.2)(typescript@7.0.2)
+      '@sanity/visual-editing-csm': 3.0.15(@sanity/client@8.2.0)(@sanity/types@6.9.2)(typescript@7.0.2)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -14626,7 +14668,7 @@ snapshots:
       styled-components: 6.5.2(react-dom@19.2.8)(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 7.26.2
+      '@sanity/client': 8.2.0(vitest@4.1.10)
       next: 16.3.1-canary.15(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
@@ -16480,6 +16522,8 @@ snapshots:
 
   eventsource-parser@3.1.1: {}
 
+  eventsource-parser@4.0.0: {}
+
   eventsource@2.0.2: {}
 
   eventsource@3.0.7:
@@ -16489,6 +16533,10 @@ snapshots:
   eventsource@4.1.1:
     dependencies:
       eventsource-parser: 3.1.1
+
+  eventsource@5.1.0:
+    dependencies:
+      eventsource-parser: 4.0.0
 
   execa@9.6.1:
     dependencies:
@@ -16868,6 +16916,12 @@ snapshots:
       is-retry-allowed: 2.2.0
       through2: 4.0.2
       tunnel-agent: 0.6.0
+
+  get-it@9.5.1(vitest@4.1.10):
+    dependencies:
+      undici: 7.29.0
+    optionalDependencies:
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
 
   get-latest-version@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ allowBuilds:
 
 catalog:
   '@next/env': 16.3.1-canary.15
-  '@sanity/client': ^7.26.2
+  '@sanity/client': ^8.2.0
   '@sanity/image-url': ^2.1.1
   '@sanity/themer': ^0.3.3
   '@sanity/tsconfig': ^2.2.1


### PR DESCRIPTION
## Summary
Renovate's #3908 bumps `@sanity/client` to `^8.2.0` but is a pure version/lockfile diff with "no application or library source edits," which is exactly why Cursor Bugbot flagged it high-risk — v8 is a breaking major and next-sanity re-exports two of the removed APIs. This PR carries the same dependency bump plus the source changes needed to actually land it:

- Drop the `unstable__adapter`/`unstable__environment` re-export from `next-sanity` (removed in `@sanity/client` v8) and the `data-adapter`/`data-environment` debug attributes that consumed them in the `mvp` and `static` demo apps.
- Route test-created Sanity clients through the client's internal `resolveFetch` hook so MSW keeps intercepting requests in the unit test suite. In Node, v8 (via get-it v9) resolves its own `undici`-backed fetch instead of calling `globalThis.fetch`, which made 54 unit tests fall through to the real network and fail with `Unauthorized - Session not found`.
- Raise the `engines.node` floor to `>=22.12` on `next-sanity` and `apps/mvp` to match `@sanity/client` v8's new Node requirement.
- Add a changeset (major, since dropping public exports is breaking for `next-sanity` consumers).

## Test plan
- [x] `pnpm --filter next-sanity test` (unit, 171 passing)
- [x] `pnpm --filter next-sanity test:e2e` (browser, 21 passing)
- [x] `pnpm lint` (`oxlint --type-check --type-aware`)
- [x] `pnpm --filter next-sanity build`
- [x] `pnpm --filter mvp build` / `pnpm --filter static build` against the public `pv8y60vp/production` dataset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major dependency upgrade with breaking `next-sanity` exports and a higher Node floor; consumers importing the removed symbols will break at compile or runtime.
> 
> **Overview**
> **Major bump:** upgrades `next-sanity` to `@sanity/client` v8 and documents it as a breaking release (Node **≥22.12**).
> 
> **Breaking public API:** stops re-exporting `unstable__adapter` and `unstable__environment` from `next-sanity` (removed upstream). Demo apps drop the related `data-adapter` / `data-environment` debug attributes.
> 
> **Tests:** adds a test `createClient` helper that sets `resolveFetch: () => fetch` so MSW can still intercept Sanity HTTP calls under v8’s undici-backed fetch.
> 
> **Tooling:** raises `engines.node` to `>=22.12` on `next-sanity` and `apps/mvp`; workspace catalog and lockfile move to `@sanity/client` ^8.2.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2363fc02b3ceb95e4d5420406560a21620382d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->