### PR TITLE
fix(deps): allow `@sanity/client` v8 without dropping v7

### DIFF
--- a/.changeset/widen-sanity-client-peer.md
+++ b/.changeset/widen-sanity-client-peer.md
@@ -1,0 +1,5 @@
+---
+"next-sanity": patch
+---
+
+fix(deps): widen allowed `@sanity/client` peer dep

--- a/.changeset/widen-sanity-client-peer.md
+++ b/.changeset/widen-sanity-client-peer.md
@@ -2,4 +2,6 @@
 "next-sanity": patch
 ---
 
-fix(deps): widen allowed `@sanity/client` peer dep
+Allow `@sanity/client` v8 as a peer while keeping v7. The installed dependency stays on v7, and `engines.node` is unchanged, so Node 20 apps are still valid.
+
+`next-sanity` no longer re-exports `unstable__adapter` and `unstable__environment`. Those names were always marked unstable and are not covered by semver. Client v8 removed them. Importing them from `next-sanity` will fail after this release on both v7 and v8.

--- a/apps/mvp/app/(website)/no-resolve-perspective/page.tsx
+++ b/apps/mvp/app/(website)/no-resolve-perspective/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -39,8 +38,6 @@ export default async function IndexPage() {
       <ContentSourceMapDebug sourceMap={sourceMap} />
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           <PostsLayout data={data} draftMode={isDraftMode} />

--- a/apps/mvp/app/(website)/only-production/page.tsx
+++ b/apps/mvp/app/(website)/only-production/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type DefinedFetchType} from 'next-sanity/live'
 import Link from 'next/link'
 
@@ -27,8 +26,6 @@ export default async function IndexPage() {
       <ContentSourceMapDebug sourceMap={sourceMap} />
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           <PostsLayout data={data} draftMode={false} />

--- a/apps/mvp/app/(website)/only-visual-editing/page.tsx
+++ b/apps/mvp/app/(website)/only-visual-editing/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -55,8 +54,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           {isDraftMode ? (

--- a/apps/mvp/app/(website)/page.tsx
+++ b/apps/mvp/app/(website)/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import {defineLive, type StrictDefinedFetchType} from 'next-sanity/live'
 import {draftMode} from 'next/headers'
 import Link from 'next/link'
@@ -57,8 +56,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="relative mx-auto max-w-7xl">
           {isDraftMode ? (

--- a/apps/static/app/page.tsx
+++ b/apps/static/app/page.tsx
@@ -1,4 +1,3 @@
-import {unstable__adapter, unstable__environment} from 'next-sanity'
 import Link from 'next/link'
 
 import PostsLayout, {type PostsLayoutProps, query} from '@/app/PostsLayout'
@@ -13,8 +12,6 @@ export default async function IndexPage() {
     <>
       <div
         className="relative bg-gray-50 px-4 pt-16 pb-20 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
-        data-adapter={unstable__adapter}
-        data-environment={unstable__environment}
       >
         <div className="absolute inset-0">
           <div className="h-1/3 bg-white sm:h-2/3" />

--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -123,7 +123,7 @@
     "vitest-package-exports": "^1.2.0"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2",
+    "@sanity/client": "^7.26.2 || ^8.0.0",
     "next": "^16.0.0-0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/packages/next-sanity/src/__tests__/exports.spec.ts
+++ b/packages/next-sanity/src/__tests__/exports.spec.ts
@@ -29,8 +29,6 @@ test(`exports snapshot for the ${JSON.stringify(env)} condition`, {timeout: 15_0
         stegaBrand: function
         stegaClean: function
         toPlainText: function
-        unstable__adapter: string
-        unstable__environment: string
         variantsApiVersion: string
       ./draft-mode:
         defineEnableDraftMode: function

--- a/packages/next-sanity/src/client.ts
+++ b/packages/next-sanity/src/client.ts
@@ -1,5 +1,5 @@
 export type * from '@sanity/client'
-export {createClient, unstable__adapter, unstable__environment} from '@sanity/client'
+export {createClient} from '@sanity/client'
 export {
   stegaBrand,
   stegaClean,

--- a/packages/next-sanity/test/SanityLive.test.tsx
+++ b/packages/next-sanity/test/SanityLive.test.tsx
@@ -1,8 +1,7 @@
-import {createClient} from 'next-sanity'
 import {SanityLive as SanityLiveClientComponent} from 'next-sanity/live/client-components'
 import {afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
-import {apiVersion, dataset, projectId, renderToString} from './helpers'
+import {apiVersion, createClient, dataset, projectId, renderToString} from './helpers'
 
 let isDraftMode = false
 let isDraftModeCalled = false

--- a/packages/next-sanity/test/helpers.ts
+++ b/packages/next-sanity/test/helpers.ts
@@ -1,7 +1,23 @@
-import type {QueryParams} from '@sanity/client'
+import type {ClientConfig, QueryParams} from '@sanity/client'
+import {createClient as createSanityClient} from 'next-sanity'
 import {prerender} from 'react-dom/static'
 
 import type {LivePerspective} from '#live/types'
+
+/**
+ * `@sanity/client` v8 (via get-it v9) resolves its own undici-backed fetch in
+ * Node instead of calling `globalThis.fetch`, so MSW (which only patches the
+ * global) can no longer intercept requests made through a plain
+ * `createClient()`. Route requests back through the global via the client's
+ * internal `resolveFetch` escape hatch — the same one its own test suite uses
+ * to inject `get-it/mock`. v7 ignores the unknown config key.
+ */
+export function createClient(config: ClientConfig) {
+  return createSanityClient({
+    ...config,
+    resolveFetch: () => fetch,
+  } as ClientConfig)
+}
 
 export const projectId = 'pv8y60vp'
 export const dataset = 'production'

--- a/packages/next-sanity/test/sanityFetch.test.ts
+++ b/packages/next-sanity/test/sanityFetch.test.ts
@@ -1,12 +1,11 @@
 import {perspectiveCookieName, variantCookieName} from '@sanity/preview-url-secret/constants'
 import {vercelStegaDecodeAll} from '@vercel/stega'
-import {createClient} from 'next-sanity'
 import {PHASE_PRODUCTION_BUILD} from 'next/constants'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import type {LivePerspective} from '#live/types'
 
-import {apiVersion, dataset, getSanityFetchMock, projectId} from './helpers'
+import {apiVersion, createClient, dataset, getSanityFetchMock, projectId} from './helpers'
 
 let isDraftMode = false
 let isDraftModeCalled = false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same peer widen as [sanity-io/visual-editing#3643](https://github.com/sanity-io/visual-editing/pull/3643), plus the source changes from [#3916](https://github.com/sanity-io/next-sanity/pull/3916), without a breaking client major.

Apps already on `@sanity/client@8` stop getting peer warnings. Apps still on v7 keep working. The installed dependency stays `^7.26.2`. `engines.node` stays `>=20.19 <22 || >=22.12`.

**Peer.** `peerDependencies["@sanity/client"]` is `^7.26.2 || ^8.0.0`. Patch changeset.

**Unstable exports.** `next-sanity` no longer re-exports `unstable__adapter` and `unstable__environment`. Those names were always marked unstable and are not covered by semver. Client v8 removed them. Demo apps drop the `data-adapter` / `data-environment` debug attributes that consumed them.

**Tests.** Unit clients go through a `resolveFetch: () => fetch` helper so MSW still intercepts under client v8. v7 ignores the unknown config key.

**Not changed.** Regular `@sanity/client` dependency, catalog, lockfile, engines.

**Verification.**
- `pnpm --filter next-sanity build` and `pnpm --filter next-sanity test -- --run` (171 passed, 12 skipped) on `@sanity/client@7.26.2`.
- Built `dist/index.d.ts` has `createClient` and does not mention `unstable__adapter` or `unstable__environment`.
- Peer range is still `^7.26.2 || ^8.0.0`. Engines still allow Node 20.
- Running `mvp` (`/`, `/only-production`, `/only-visual-editing`, `/no-resolve-perspective`) and `static` (`/`) all return 200 with no leftover adapter/environment markers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0729522-3dbf-4e63-82b4-7ca9c1aae403?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0729522-3dbf-4e63-82b4-7ca9c1aae403&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

