### PR TITLE
fix: recover draft mode with the Storage Access API when browsers reject Partitioned cookies (Firefox ETP)

### DIFF
--- a/.changeset/firefox-etp-storage-access-fallback.md
+++ b/.changeset/firefox-etp-storage-access-fallback.md
@@ -1,0 +1,7 @@
+---
+"next-sanity": patch
+---
+
+fix: recover draft mode with the Storage Access API when browsers reject `Partitioned` cookies in cross-site Presentation iframes (Firefox Enhanced Tracking Protection)
+
+`defineEnableDraftMode` now verifies that the browser actually stored the draft-mode cookies before redirecting to the preview. When they were rejected (for example Firefox with Enhanced Tracking Protection configured to block all third-party cookies logs `Cookie "__prerender_bypass" has been rejected as third-party` even with the CHIPS `Partitioned` attribute), the route serves an interstitial inside the Presentation iframe that requests unpartitioned cookie access through `document.requestStorageAccess()` and retries, instead of silently redirecting to a preview that can never enter draft mode. Requests carrying `Sec-Fetch-Storage-Access: inactive` are retried with the already-granted permission activated (Storage Access Headers), and `<VisualEditing>` re-activates an existing grant per document so RSC requests and server actions keep sending the cookies. When the browser refuses storage access altogether, the interstitial explains how to unblock the preview (allow cross-site cookies for the Studio, or open the preview in a new tab) rather than failing with "Unable to connect to visual editing".

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -18,6 +18,8 @@ The all-in-one [Sanity][sanity] toolkit for production-grade content-editable Ne
 - [Manual installation](#manual-installation)
   - [Install `next-sanity`](#install-next-sanity)
   - [Optional: peer dependencies for embedded Sanity Studio](#optional-peer-dependencies-for-embedded-sanity-studio)
+- [Troubleshooting](#troubleshooting)
+  - [Draft mode cookies are blocked in the Presentation Tool](#draft-mode-cookies-are-blocked-in-the-presentation-tool)
 - [Migration guides](#migration-guides)
 - [License](#license)
 
@@ -71,6 +73,23 @@ When using `npm` newer than `v7`, or `pnpm` newer than `v8`, you should end up w
 npx install-peerdeps --yarn next-sanity
 ```
 
+## Troubleshooting
+
+### Draft mode cookies are blocked in the Presentation Tool
+
+When the Presentation Tool loads your site in a cross-site iframe (for example a Studio hosted on `*.sanity.studio` previewing your production domain), `defineEnableDraftMode` sets the draft-mode cookies with the CHIPS `Partitioned` attribute so browsers that block third-party cookies (Chrome, Safari 18.4+) still store them.
+
+Some browser configurations reject even `Partitioned` cookies — most commonly Firefox with Enhanced Tracking Protection set to block all cross-site cookies, which logs errors like:
+
+```
+Cookie "__prerender_bypass" has been rejected as third-party.
+```
+
+`defineEnableDraftMode` detects this and shows a dialog inside the preview iframe that requests cookie access through the [Storage Access API][storage-access-api] and retries. If the browser denies storage access there is no programmatic escape hatch; the dialog then explains the remaining options:
+
+- Allow cross-site cookies for the Studio site — in Firefox, click the shield icon in the address bar and turn off Enhanced Tracking Protection for the Studio, then reload the preview.
+- Open the preview in a new tab, where the cookies are first-party and always allowed.
+
 ## Migration guides
 
 - [From `v12` to `v13`][migrate-v12-to-v13]
@@ -112,6 +131,7 @@ MIT-licensed. See [LICENSE][LICENSE].
 [sanity-next-client]: https://www.sanity.io/docs/nextjs/configure-sanity-client-nextjs
 [app-router-vised]: https://www.sanity.io/docs/visual-editing/visual-editing-with-next-js-app-router
 [sanity-reference-docs]: https://reference.sanity.io/next-sanity/
+[storage-access-api]: https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API
 [sanity-next-caching]: https://www.sanity.io/docs/nextjs/caching-and-revalidation-in-nextjs
 [next-queries]: https://www.sanity.io/docs/nextjs/query-content-nextjs
 [next-sanity-intro]: https://www.sanity.io/docs/nextjs/introduction

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -85,7 +85,7 @@ Some browser configurations reject even `Partitioned` cookies — most commonly 
 Cookie "__prerender_bypass" has been rejected as third-party.
 ```
 
-`defineEnableDraftMode` detects this and shows a dialog inside the preview iframe that requests cookie access through the [Storage Access API][storage-access-api] and retries. If the browser denies storage access there is no programmatic escape hatch; the dialog then explains the remaining options:
+`defineEnableDraftMode` detects this and shows a dialog inside the preview iframe that requests cookie access through the [Storage Access API][storage-access-api] and retries. If the Presentation Tool reports "Unable to connect" on top of the preview, choose "Continue anyway" to interact with the dialog. If the browser denies storage access there is no programmatic escape hatch; the dialog then explains the remaining options:
 
 - Allow cross-site cookies for the Studio site — in Firefox, click the shield icon in the address bar and turn off Enhanced Tracking Protection for the Studio, then reload the preview.
 - Open the preview in a new tab, where the cookies are first-party and always allowed.

--- a/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
+++ b/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
@@ -33,6 +33,16 @@ export const probeSearchParam = 'sanity-preview-probe'
 const maxAutoCookieAttempts = 2
 
 /**
+ * Upper bound for the probe redirects issued by `defineEnableDraftMode`.
+ * Cookieless probe requests with storage access active re-probe (their
+ * Set-Cookie is the first one to target the just-unblocked unpartitioned jar),
+ * and this cap keeps that from looping when even those cookies are rejected.
+ *
+ * @internal
+ */
+export const maxProbeAttempts = 3
+
+/**
  * @internal
  */
 export interface CookieAccessInterstitialOptions {
@@ -125,7 +135,10 @@ export function renderCookieAccessInterstitial(options: CookieAccessInterstitial
           browser &mdash; in Firefox, open the shield icon in the address bar and turn off Enhanced
           Tracking Protection for the Studio, then reload the preview.
         </p>
-        <p><a id="new-tab" target="_blank">Open the preview in a new tab</a> instead.</p>
+        <p>
+          <a id="new-tab" target="_blank" rel="noopener noreferrer">Open the preview in a new tab</a>
+          instead.
+        </p>
       </div>
       <p id="status" role="status"></p>
       <noscript>

--- a/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
+++ b/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
@@ -1,0 +1,208 @@
+/**
+ * Fallback flow for browsers that reject the draft-mode cookies set from a
+ * cross-site Presentation iframe (e.g. Firefox with Enhanced Tracking
+ * Protection configured to block all third-party cookies, where even CHIPS
+ * `Partitioned` cookies are "rejected as third-party").
+ *
+ * `defineEnableDraftMode` sets the cookies and then redirects back to itself
+ * with {@link probeSearchParam} to verify the browser actually stored them.
+ * When the probe request arrives without the draft-mode cookie, the route
+ * serves the interstitial rendered by {@link renderCookieAccessInterstitial}
+ * instead of silently redirecting to a preview that can never enter draft
+ * mode. The interstitial requests unpartitioned cookie access through the
+ * Storage Access API and retries, or explains how to unblock the preview when
+ * the browser refuses.
+ *
+ * @see https://github.com/sanity-io/next-sanity/issues/3919
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API
+ */
+
+/**
+ * Search param used by `defineEnableDraftMode` to verify that the browser
+ * stored the draft-mode cookies. Its value is the number of Set-Cookie
+ * attempts made so far, so the interstitial can stop auto-retrying.
+ *
+ * @internal
+ */
+export const probeSearchParam = 'sanity-preview-probe'
+
+/**
+ * Automatic retries stop once this many Set-Cookie attempts have been probed;
+ * beyond it the interstitial only retries on explicit user interaction.
+ *
+ * @internal
+ */
+export const maxAutoCookieAttempts = 2
+
+/**
+ * @internal
+ */
+export interface CookieAccessInterstitialOptions {
+  /** How many Set-Cookie attempts have been probed so far */
+  attempt: number
+}
+
+/**
+ * Renders the interstitial shown inside the Presentation iframe when the
+ * browser refused to store the draft-mode cookies. All dynamic values are
+ * numbers or compile-time constants, so the markup cannot be influenced by
+ * request input.
+ *
+ * @internal
+ */
+export function renderCookieAccessInterstitial(options: CookieAccessInterstitialOptions): string {
+  const attempt = Math.max(0, Math.trunc(options.attempt))
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Allow preview cookies</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        display: grid;
+        place-items: center;
+        font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+        background: light-dark(#fff, #13141b);
+        color: light-dark(#13141b, #e2e3e9);
+      }
+      main {
+        max-width: 28rem;
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      h1 {
+        font-size: 1.125rem;
+        margin: 0 0 0.5rem;
+      }
+      p {
+        font-size: 0.875rem;
+        line-height: 1.5;
+        margin: 0 0 1rem;
+        color: light-dark(#515360, #9a9cab);
+      }
+      button {
+        font: inherit;
+        font-weight: 600;
+        padding: 0.5rem 1.25rem;
+        border-radius: 0.375rem;
+        border: 1px solid transparent;
+        background: #556bfc;
+        color: #fff;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #4055f1;
+      }
+      a {
+        color: light-dark(#556bfc, #7b8cff);
+      }
+      #status {
+        font-size: 0.8125rem;
+        min-height: 1.25rem;
+        margin: 0.75rem 0 0;
+      }
+      [hidden] {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Allow preview cookies</h1>
+      <p>
+        Your browser blocked the cookies needed to preview drafts while this site is embedded in
+        Sanity Studio.
+      </p>
+      <button id="continue" hidden>Allow preview cookies</button>
+      <div id="guidance" hidden>
+        <p>
+          To preview drafts inside the Studio, allow cross-site cookies for this site in your
+          browser &mdash; in Firefox, open the shield icon in the address bar and turn off Enhanced
+          Tracking Protection for the Studio, then reload the preview.
+        </p>
+        <p><a id="new-tab" target="_blank">Open the preview in a new tab</a> instead.</p>
+      </div>
+      <p id="status" role="status"></p>
+      <noscript>
+        <p>
+          JavaScript is disabled. Allow cross-site cookies for this site in your browser settings,
+          or open this URL directly in a new tab.
+        </p>
+      </noscript>
+    </main>
+    <script>
+      ;(function () {
+        'use strict'
+        var PROBE_PARAM = ${JSON.stringify(probeSearchParam)}
+        var attempt = ${attempt}
+        var maxAutoAttempts = ${maxAutoCookieAttempts}
+        var button = document.getElementById('continue')
+        var guidance = document.getElementById('guidance')
+        var status = document.getElementById('status')
+
+        var enableUrl = new URL(location.href)
+        enableUrl.searchParams.delete(PROBE_PARAM)
+        document.getElementById('new-tab').href = enableUrl.href
+
+        function retry() {
+          var url = new URL(location.href)
+          url.searchParams.set(PROBE_PARAM, String(attempt + 1))
+          location.replace(url.pathname + url.search)
+        }
+
+        function showGuidance(message) {
+          status.textContent = message
+          guidance.hidden = false
+        }
+
+        var supported =
+          typeof document.hasStorageAccess === 'function' &&
+          typeof document.requestStorageAccess === 'function'
+        if (!supported) {
+          showGuidance('')
+          return
+        }
+
+        button.hidden = false
+        button.addEventListener('click', function () {
+          status.textContent = ''
+          document.requestStorageAccess().then(
+            function () {
+              status.textContent = 'Access granted, loading preview\\u2026'
+              retry()
+            },
+            function () {
+              showGuidance('Your browser denied storage access.')
+            },
+          )
+        })
+
+        if (attempt >= maxAutoAttempts) {
+          showGuidance('The preview cookies are still blocked after granting access.')
+          return
+        }
+
+        // If storage access was granted in an earlier session it can be
+        // re-activated without a user gesture, so retry automatically.
+        if (navigator.permissions && typeof navigator.permissions.query === 'function') {
+          navigator.permissions.query({name: 'storage-access'}).then(function (result) {
+            if (result.state !== 'granted') return
+            document.requestStorageAccess().then(function () {
+              status.textContent = 'Loading preview\\u2026'
+              retry()
+            }, function () {})
+          }, function () {})
+        }
+      })()
+    </script>
+  </body>
+</html>
+`
+}

--- a/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
+++ b/packages/next-sanity/src/draft-mode/cookie-access-fallback.ts
@@ -29,10 +29,8 @@ export const probeSearchParam = 'sanity-preview-probe'
 /**
  * Automatic retries stop once this many Set-Cookie attempts have been probed;
  * beyond it the interstitial only retries on explicit user interaction.
- *
- * @internal
  */
-export const maxAutoCookieAttempts = 2
+const maxAutoCookieAttempts = 2
 
 /**
  * @internal

--- a/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
+++ b/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
@@ -6,7 +6,11 @@ import {redirect} from 'next/navigation'
 
 import {partitionedCookieName} from '#live/constants'
 
-import {probeSearchParam, renderCookieAccessInterstitial} from './cookie-access-fallback'
+import {
+  maxProbeAttempts,
+  probeSearchParam,
+  renderCookieAccessInterstitial,
+} from './cookie-access-fallback'
 
 /**
  * @public
@@ -94,13 +98,19 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
       // so we need an explicit option
       const isSecure = isProduction || (options.secureDevMode ?? false)
 
+      const url = new URL(request.url)
+      const probedAttempt = Number.parseInt(url.searchParams.get(probeSearchParam) ?? '', 10)
+      const isProbe = Number.isInteger(probedAttempt) && probedAttempt >= 1
+
+      // `Sec-Fetch-Site` reflects the navigation's initiator, so retries
+      // initiated by the interstitial inside the cross-site iframe arrive as
+      // `same-origin`. The probe param only enters the flow through this
+      // route's own cross-site handling, so its presence carries the
+      // cross-site signal across those retries.
       const crossSiteIframe =
         isSecure &&
         request.headers.get('sec-fetch-dest') === 'iframe' &&
-        request.headers.get('sec-fetch-site') === 'cross-site'
-
-      const url = new URL(request.url)
-      const probedAttempt = Number.parseInt(url.searchParams.get(probeSearchParam) ?? '', 10)
+        (request.headers.get('sec-fetch-site') === 'cross-site' || isProbe)
 
       // Storage Access Headers: `inactive` means the browser has already
       // granted the `storage-access` permission but did not activate it for
@@ -113,13 +123,7 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
       // permission grant must not divert cookies into the unpartitioned jar
       // in browsers where the partitioned jar works fine.
       const storageAccess = request.headers.get('sec-fetch-storage-access')
-      if (
-        crossSiteIframe &&
-        !hasBypassCookie &&
-        storageAccess === 'inactive' &&
-        Number.isInteger(probedAttempt) &&
-        probedAttempt >= 1
-      ) {
+      if (crossSiteIframe && !hasBypassCookie && storageAccess === 'inactive' && isProbe) {
         return new Response(renderCookieAccessInterstitial({attempt: probedAttempt}), {
           status: 401,
           headers: {
@@ -226,17 +230,23 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
       // Browsers with strict tracking protection can reject all of the cookies
       // set above, even with `Partitioned`, and there is no server-side signal
       // for it. Unless this request proves cookies already work, redirect back
-      // to this route once so the next request reveals whether they stuck.
+      // to this route so the next request reveals whether they stuck. A
+      // cookieless probe with storage access active also re-probes: its
+      // Set-Cookie above is the first one to target the just-unblocked
+      // unpartitioned jar, so it deserves a probe of its own instead of being
+      // declared a failure - bounded to avoid redirect loops when even those
+      // cookies are rejected.
       if (crossSiteIframe && !hasBypassCookie) {
-        if (!Number.isInteger(probedAttempt) || probedAttempt < 1) {
-          url.searchParams.set(probeSearchParam, '1')
+        const attempt = isProbe ? probedAttempt : 0
+        if (attempt === 0 || (storageAccess === 'active' && attempt < maxProbeAttempts)) {
+          url.searchParams.set(probeSearchParam, String(attempt + 1))
           redirect(`${url.pathname}${url.search}`)
         }
 
         // The probe request came back without the cookie: the browser rejected
         // it. Serve the Storage Access API interstitial instead of a preview
         // that can never enter draft mode.
-        return new Response(renderCookieAccessInterstitial({attempt: probedAttempt}), {
+        return new Response(renderCookieAccessInterstitial({attempt}), {
           status: 200,
           headers: {
             'Content-Type': 'text/html; charset=utf-8',

--- a/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
+++ b/packages/next-sanity/src/draft-mode/define-enable-draft-mode.ts
@@ -6,6 +6,8 @@ import {redirect} from 'next/navigation'
 
 import {partitionedCookieName} from '#live/constants'
 
+import {probeSearchParam, renderCookieAccessInterstitial} from './cookie-access-fallback'
+
 /**
  * @public
  */
@@ -36,7 +38,20 @@ export interface EnableDraftMode {
  * them despite third-party cookie blocking. Top-level / same-site requests keep
  * unpartitioned cookies so `draftMode().disable()` continues to work.
  *
+ * Some browsers reject even `Partitioned` cookies in cross-site iframes, for
+ * example Firefox with Enhanced Tracking Protection configured to block all
+ * third-party cookies ("Cookie has been rejected as third-party"). Because a
+ * silent redirect would then land on a preview that can never enter draft
+ * mode, cross-site iframe requests are redirected back to this route once with
+ * a probe search param to verify the cookies were stored. If they were not,
+ * the route responds with an interstitial that requests unpartitioned cookie
+ * access through the Storage Access API and retries, or explains how to
+ * unblock the preview when the browser refuses. Requests that carry the
+ * `Sec-Fetch-Storage-Access: inactive` header are asked to retry with the
+ * already-granted permission activated (Storage Access Headers).
+ *
  * @see https://github.com/sanity-io/sanity/issues/12806
+ * @see https://github.com/sanity-io/next-sanity/issues/3919
  *
  * @example
  * ```ts
@@ -56,11 +71,10 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
   const {client} = options
   return {
     GET: async (request: Request) => {
-      // @TODO check if already in draft mode at a much earlier stage, and skip validation
-
       const {
         isValid,
         redirectTo = '/',
+        studioOrigin,
         studioPreviewPerspective,
         studioPreviewVariant,
       } = await validatePreviewUrl(client, request.url)
@@ -70,10 +84,9 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
 
       const draftModeStore = await draftMode()
 
-      // Let's enable draft mode if it's not already enabled
-      if (!draftModeStore.isEnabled) {
-        draftModeStore.enable()
-      }
+      // A valid bypass cookie on the request proves the browser stores and
+      // sends the draft-mode cookies in this context.
+      const hasBypassCookie = draftModeStore.isEnabled
 
       const isProduction = process.env.NODE_ENV === 'production'
 
@@ -81,15 +94,57 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
       // so we need an explicit option
       const isSecure = isProduction || (options.secureDevMode ?? false)
 
-      // Safari blocks unpartitioned third-party cookies. When the enable route is
-      // hit from a cross-site iframe (Presentation), opt into CHIPS so the cookies
-      // are stored under the studio's partition. Skip partitioning for top-level /
-      // same-site requests so draftMode().disable() can still clear them.
-      // https://github.com/sanity-io/sanity/issues/12806
-      const partitioned =
+      const crossSiteIframe =
         isSecure &&
         request.headers.get('sec-fetch-dest') === 'iframe' &&
         request.headers.get('sec-fetch-site') === 'cross-site'
+
+      const url = new URL(request.url)
+      const probedAttempt = Number.parseInt(url.searchParams.get(probeSearchParam) ?? '', 10)
+
+      // Storage Access Headers: `inactive` means the browser has already
+      // granted the `storage-access` permission but did not activate it for
+      // this navigation. Once a probe has proven that the partitioned cookies
+      // were rejected, ask the browser to retry the request with the
+      // permission active so the cookies below are stored in, and read from,
+      // the unpartitioned jar. Supporting browsers retry at most once. The
+      // first, un-probed attempt is deliberately excluded: CHIPS partitioned
+      // cookies are the reliable default for cross-site iframes, and a stale
+      // permission grant must not divert cookies into the unpartitioned jar
+      // in browsers where the partitioned jar works fine.
+      const storageAccess = request.headers.get('sec-fetch-storage-access')
+      if (
+        crossSiteIframe &&
+        !hasBypassCookie &&
+        storageAccess === 'inactive' &&
+        Number.isInteger(probedAttempt) &&
+        probedAttempt >= 1
+      ) {
+        return new Response(renderCookieAccessInterstitial({attempt: probedAttempt}), {
+          status: 401,
+          headers: {
+            'Activate-Storage-Access': `retry; allowed-origin=${studioOrigin ? `"${studioOrigin}"` : '*'}`,
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store',
+            'Vary': 'Sec-Fetch-Storage-Access',
+          },
+        })
+      }
+
+      // Let's enable draft mode if it's not already enabled
+      if (!draftModeStore.isEnabled) {
+        draftModeStore.enable()
+      }
+
+      // Safari blocks unpartitioned third-party cookies. When the enable route is
+      // hit from a cross-site iframe (Presentation), opt into CHIPS so the cookies
+      // are stored under the studio's partition. Skip partitioning for top-level /
+      // same-site requests so draftMode().disable() can still clear them. Skip it
+      // as well when storage access is active for this request: those cookies
+      // belong in the unpartitioned jar the Storage Access API just unblocked -
+      // `Partitioned` would put them back in the jar the browser is blocking.
+      // https://github.com/sanity-io/sanity/issues/12806
+      const partitioned = crossSiteIframe && storageAccess !== 'active'
 
       // Override cookie header for draft mode for usage in live-preview
       // https://github.com/vercel/next.js/issues/49927
@@ -154,6 +209,39 @@ export function defineEnableDraftMode(options: DefineEnableDraftModeOptions): En
           secure: true,
           sameSite: 'none',
           partitioned: true,
+        })
+      } else if (crossSiteIframe) {
+        // Storage access is active, so the cookies above are unpartitioned.
+        // Clear a stale flag cookie so server actions stop partitioning writes.
+        cookieStore.delete({
+          name: partitionedCookieName,
+          httpOnly: true,
+          path: '/',
+          secure: true,
+          sameSite: 'none',
+          partitioned: true,
+        })
+      }
+
+      // Browsers with strict tracking protection can reject all of the cookies
+      // set above, even with `Partitioned`, and there is no server-side signal
+      // for it. Unless this request proves cookies already work, redirect back
+      // to this route once so the next request reveals whether they stuck.
+      if (crossSiteIframe && !hasBypassCookie) {
+        if (!Number.isInteger(probedAttempt) || probedAttempt < 1) {
+          url.searchParams.set(probeSearchParam, '1')
+          redirect(`${url.pathname}${url.search}`)
+        }
+
+        // The probe request came back without the cookie: the browser rejected
+        // it. Serve the Storage Access API interstitial instead of a preview
+        // that can never enter draft mode.
+        return new Response(renderCookieAccessInterstitial({attempt: probedAttempt}), {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store',
+          },
         })
       }
 

--- a/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
+++ b/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
@@ -53,6 +53,38 @@ export default function VisualEditing(props: VisualEditingProps): React.JSX.Elem
   const router = useRouter()
   const [navigate, setNavigate] = useState<HistoryAdapterNavigate | undefined>()
 
+  // When draft mode was enabled through the Storage Access API fallback in
+  // `defineEnableDraftMode` (browsers that reject cross-site cookies even with
+  // CHIPS, e.g. Firefox with strict Enhanced Tracking Protection), the
+  // draft-mode cookies live in the unpartitioned jar. Storage access is
+  // granted per document in some browsers, so re-activate the existing grant
+  // for this document to keep the cookies flowing on RSC requests and server
+  // actions. This never prompts: without a prior grant `requestStorageAccess`
+  // rejects and the partitioned-cookie behavior stays untouched.
+  // https://github.com/sanity-io/next-sanity/issues/3919
+  useEffect(() => {
+    if (
+      window.self === window.top ||
+      typeof document.hasStorageAccess !== 'function' ||
+      typeof document.requestStorageAccess !== 'function'
+    ) {
+      return undefined
+    }
+    const controller = new AbortController()
+    document
+      .hasStorageAccess()
+      .then(async (hasAccess) => {
+        if (hasAccess || controller.signal.aborted) return
+        const permission = await navigator.permissions.query({name: 'storage-access'})
+        if (permission.state !== 'granted' || controller.signal.aborted) return
+        await document.requestStorageAccess()
+      })
+      .catch(() => {
+        // Not granted or unsupported - cookies keep using the partitioned jar.
+      })
+    return () => controller.abort()
+  }, [])
+
   const history = useMemo<HistoryAdapter>(
     () => ({
       subscribe: (_navigate) => {

--- a/packages/next-sanity/test/defineEnableDraftMode.test.ts
+++ b/packages/next-sanity/test/defineEnableDraftMode.test.ts
@@ -490,10 +490,12 @@ describe('cookie access fallback (Firefox ETP)', () => {
     )
   })
 
-  test('sets unpartitioned cookies and clears the flag cookie when storage access is active', async () => {
+  test('sets unpartitioned cookies, clears the flag cookie, and re-probes when storage access is active', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const GET = await importGET()
 
+    // The active request writes the unpartitioned jar for the first time, so
+    // those cookies get a probe hop of their own instead of the interstitial.
     await expect(
       GET(
         createRequest(
@@ -501,7 +503,9 @@ describe('cookie access fallback (Firefox ETP)', () => {
           {'sanity-preview-probe': '1'},
         ),
       ),
-    ).resolves.toHaveProperty('status', 200)
+    ).rejects.toThrow(
+      'REDIRECT:/api/draft-mode/enable?sanity-preview-secret=secret&sanity-preview-probe=2',
+    )
 
     expect(cookieSet).toHaveBeenCalledWith({
       name: '__prerender_bypass',
@@ -521,6 +525,40 @@ describe('cookie access fallback (Firefox ETP)', () => {
       sameSite: 'none',
       partitioned: true,
     })
+  })
+
+  test('stops re-probing active requests at the attempt cap', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    const response = await GET(
+      createRequest(
+        {...iframeHeaders, 'sec-fetch-storage-access': 'active'},
+        {'sanity-preview-probe': '3'},
+      ),
+    )
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('var attempt = 3')
+  })
+
+  test('treats interstitial retries as the cross-site iframe flow via the probe param', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    // Retries are navigations initiated by the interstitial document itself,
+    // so Sec-Fetch-Site is same-origin even though the iframe is cross-site.
+    const response = await GET(
+      createRequest(
+        {'sec-fetch-dest': 'iframe', 'sec-fetch-site': 'same-origin'},
+        {'sanity-preview-probe': '2'},
+      ),
+    )
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('var attempt = 2')
+    // The retry keeps re-attempting the partitioned CHIPS regime
+    expect(cookieSet).toHaveBeenCalledWith(
+      expect.objectContaining({name: '__prerender_bypass', partitioned: true}),
+    )
   })
 })
 

--- a/packages/next-sanity/test/defineEnableDraftMode.test.ts
+++ b/packages/next-sanity/test/defineEnableDraftMode.test.ts
@@ -127,11 +127,16 @@ afterEach(() => {
   vi.resetModules()
 })
 
-function createRequest(headers?: Record<string, string>) {
-  return new Request('https://example.com/api/draft-mode/enable?sanity-preview-secret=secret', {
-    headers,
-  })
+function createRequest(headers?: Record<string, string>, searchParams?: Record<string, string>) {
+  const url = new URL('https://example.com/api/draft-mode/enable?sanity-preview-secret=secret')
+  for (const [key, value] of Object.entries(searchParams ?? {})) {
+    url.searchParams.set(key, value)
+  }
+  return new Request(url, {headers})
 }
+
+const probeRedirect =
+  'REDIRECT:/api/draft-mode/enable?sanity-preview-secret=secret&sanity-preview-probe=1'
 
 describe('defineEnableDraftMode', () => {
   test('sets Partitioned cookies and flag cookie for cross-site iframe in production', async () => {
@@ -149,7 +154,7 @@ describe('defineEnableDraftMode', () => {
           'sec-fetch-site': 'cross-site',
         }),
       ),
-    ).rejects.toThrow('REDIRECT:/preview')
+    ).rejects.toThrow(probeRedirect)
 
     expect(draftModeEnable).toHaveBeenCalledOnce()
     expect(cookieSet).toHaveBeenCalledWith({
@@ -283,7 +288,7 @@ describe('defineEnableDraftMode', () => {
           'sec-fetch-site': 'cross-site',
         }),
       ),
-    ).rejects.toThrow('REDIRECT:/preview')
+    ).rejects.toThrow(probeRedirect)
 
     expect(cookieSet).toHaveBeenCalledWith({
       name: '__prerender_bypass',
@@ -341,7 +346,7 @@ describe('defineEnableDraftMode', () => {
           'sec-fetch-site': 'cross-site',
         }),
       ),
-    ).rejects.toThrow('REDIRECT:/preview')
+    ).rejects.toThrow(probeRedirect)
 
     expect(cookieSet).toHaveBeenCalledWith({
       name: variantCookieName,
@@ -371,11 +376,145 @@ describe('defineEnableDraftMode', () => {
           'sec-fetch-site': 'cross-site',
         }),
       ),
-    ).rejects.toThrow('REDIRECT:/preview')
+    ).rejects.toThrow(probeRedirect)
 
     expect(cookieSet.mock.calls.some((call) => call[0]?.name === variantCookieName)).toBe(false)
     expect(cookieDelete).toHaveBeenCalledWith({
       name: variantCookieName,
+      httpOnly: true,
+      path: '/',
+      secure: true,
+      sameSite: 'none',
+      partitioned: true,
+    })
+  })
+})
+
+async function importGET() {
+  const {defineEnableDraftMode} = await import('../src/draft-mode/define-enable-draft-mode')
+  return defineEnableDraftMode({
+    // oxlint-disable-next-line no-unsafe-type-assertion
+    client: {} as never,
+  }).GET
+}
+
+describe('cookie access fallback (Firefox ETP)', () => {
+  const iframeHeaders = {
+    'sec-fetch-dest': 'iframe',
+    'sec-fetch-site': 'cross-site',
+  }
+
+  test('skips the probe when the request already carries the bypass cookie', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    isDraftMode = true
+    const GET = await importGET()
+
+    await expect(GET(createRequest(iframeHeaders))).rejects.toThrow('REDIRECT:/preview')
+    expect(draftModeEnable).not.toHaveBeenCalled()
+  })
+
+  test('redirects the probe request onwards when the cookie stuck', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    isDraftMode = true
+    const GET = await importGET()
+
+    await expect(GET(createRequest(iframeHeaders, {'sanity-preview-probe': '1'}))).rejects.toThrow(
+      'REDIRECT:/preview',
+    )
+  })
+
+  test('serves the Storage Access API interstitial when the probe comes back cookieless', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    const response = await GET(createRequest(iframeHeaders, {'sanity-preview-probe': '1'}))
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/html; charset=utf-8')
+    expect(response.headers.get('cache-control')).toBe('no-store')
+    const html = await response.text()
+    expect(html).toContain('requestStorageAccess')
+    expect(html).toContain('var attempt = 1')
+    expect(html).toContain('sanity-preview-probe')
+    // The interstitial response retries the Set-Cookie attempt as well
+    expect(cookieSet).toHaveBeenCalledWith(
+      expect.objectContaining({name: '__prerender_bypass', partitioned: true}),
+    )
+  })
+
+  test('stops auto-retrying once the attempt limit is reached', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    const response = await GET(createRequest(iframeHeaders, {'sanity-preview-probe': '2'}))
+    expect(response.status).toBe(200)
+    const html = await response.text()
+    expect(html).toContain('var attempt = 2')
+    expect(html).toContain('var maxAutoAttempts = 2')
+  })
+
+  test('asks probed requests with an inactive storage-access permission to retry', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    validatePreviewUrl.mockResolvedValue({
+      isValid: true,
+      redirectTo: '/preview',
+      studioOrigin: 'https://my.sanity.studio',
+      studioPreviewPerspective: 'drafts',
+    })
+    const GET = await importGET()
+
+    const response = await GET(
+      createRequest(
+        {...iframeHeaders, 'sec-fetch-storage-access': 'inactive'},
+        {'sanity-preview-probe': '1'},
+      ),
+    )
+    expect(response.status).toBe(401)
+    expect(response.headers.get('activate-storage-access')).toBe(
+      'retry; allowed-origin="https://my.sanity.studio"',
+    )
+    expect(response.headers.get('vary')).toBe('Sec-Fetch-Storage-Access')
+    // No cookies are set on the retry response
+    expect(cookieSet).not.toHaveBeenCalled()
+  })
+
+  test('leaves the first attempt to CHIPS even when a storage-access permission exists', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    await expect(
+      GET(createRequest({...iframeHeaders, 'sec-fetch-storage-access': 'inactive'})),
+    ).rejects.toThrow(probeRedirect)
+
+    expect(cookieSet).toHaveBeenCalledWith(
+      expect.objectContaining({name: '__prerender_bypass', partitioned: true}),
+    )
+  })
+
+  test('sets unpartitioned cookies and clears the flag cookie when storage access is active', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const GET = await importGET()
+
+    await expect(
+      GET(
+        createRequest(
+          {...iframeHeaders, 'sec-fetch-storage-access': 'active'},
+          {'sanity-preview-probe': '1'},
+        ),
+      ),
+    ).resolves.toHaveProperty('status', 200)
+
+    expect(cookieSet).toHaveBeenCalledWith({
+      name: '__prerender_bypass',
+      value: 'bypass-secret',
+      httpOnly: true,
+      path: '/',
+      secure: true,
+      sameSite: 'none',
+      partitioned: false,
+    })
+    expect(cookieSet.mock.calls.some((call) => call[0]?.name === partitionedCookieName)).toBe(false)
+    expect(cookieDelete).toHaveBeenCalledWith({
+      name: partitionedCookieName,
       httpOnly: true,
       path: '/',
       secure: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #3919.

Firefox with Enhanced Tracking Protection configured to block all cross-site cookies rejects the draft-mode cookies set from a cross-site Presentation iframe even with the CHIPS `Partitioned` attribute:

```
Cookie "__prerender_bypass=…; SameSite=none; Partitioned" has been rejected as third-party.
```

Unlike Chrome and Safari 18.4+, Firefox does not treat CHIPS as an opt-in escape from cookie blocking (its Total Cookie Protection partitions automatically, and its blocking configurations reject everything). The enable route then redirects into a preview that can never enter draft mode, and Presentation fails with the cryptic "Unable to connect to visual editing".

## Fix

Layered fallback in `defineEnableDraftMode`, keeping CHIPS as the first attempt so working browsers see no behavior change:

1. **Cookie verification probe** — cross-site iframe requests that don't already carry the bypass cookie are redirected back to the enable route once with a `sanity-preview-probe` search param. If the probe arrives with the cookie, it redirects onwards as before (one extra same-origin hop, only on the first load).
2. **Storage Access API interstitial** — if the probe arrives cookieless, the browser rejected the cookies. Instead of a silent broken redirect, the route serves an interstitial inside the iframe that calls `document.requestStorageAccess()` (auto-continuing without a click when the permission was granted previously) and retries the enable flow. Retries are loop-guarded via the probe attempt counter.
3. **Storage Access Headers** — probed requests carrying `Sec-Fetch-Storage-Access: inactive` get a `401` + `Activate-Storage-Access: retry; allowed-origin="<studio origin>"` so supporting browsers retry the request with the permission active; cookies set while access is active skip `Partitioned` (they belong in the unpartitioned jar the grant unblocks) and clear the `sanity-preview-partitioned` flag cookie so server actions follow suit.
4. **`<VisualEditing>`** re-activates an existing storage-access grant per document (never prompts), keeping RSC requests and server actions sending the cookies in browsers with per-document grant semantics.
5. When the browser refuses storage access altogether (current Firefox denies it when all third-party cookies are blocked), the interstitial explains the actionable remedies (allow cross-site cookies for the Studio via the ETP shield, or open the preview in a new tab) instead of failing silently. README gains a troubleshooting section keyed to the exact console error.

Note on Presentation UX: while visual editing is not connected, Presentation gates iframe interaction behind its "connecting…" overlay; the user clicks its "Continue anyway" button to interact with the interstitial (documented in the README). The auto-continue path (previously granted permission) needs no interaction at all.

## Empirical grounding

Verified against real Firefox (Playwright build 153) with a two-origin HTTPS lab (`studio.test` embedding `site.test`):

- Reproduced the exact rejection from the issue under "block all third-party cookies" (`network.cookie.cookieBehavior=1`): both plain and `Partitioned` cookies are dropped, and `requestStorageAccess()` is auto-denied — hence the guidance path.
- Under default ETP (behavior 5) and Firefox's opt-in-partitioning future (`network.cookie.cookieBehavior.optInPartitioning=true`), `Partitioned` cookies work and the new probe passes straight through — no interstitial.
- Confirmed Firefox supports Storage Access Headers (`Sec-Fetch-Storage-Access` / `Activate-Storage-Access: retry`), that cookies set while access is active land in the unpartitioned jar, and that iframe navigations only ever attach the partitioned jar (which is why the CHIPS-first ordering matters).

## Test plan

- 23 unit tests in `defineEnableDraftMode.test.ts` (7 new) covering the probe redirect, success pass-through, interstitial rendering and loop guard, Storage Access Headers handling, CHIPS-first ordering, and the unpartitioned/flag-cookie regime under active storage access. `pnpm lint`, `pnpm knip`, `pnpm build`, `pnpm test`, and `pnpm test:e2e` all pass.
- End-to-end against a real Next.js 16 app (`next dev --experimental-https` on `site.test`, embedded cross-site from `studio.test`, `defineEnableDraftMode` with a stubbed client):
  - **Firefox, default ETP**: probe passes, `draftMode: ENABLED` — no regression.
    [Firefox default ETP, draft mode enabled](https://cursor.com/agents/bc-79191563-eaa7-4386-9ed4-54ed153201a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox_default_etp_draft_mode_enabled.png)
  - **Firefox, ETP blocking all cross-site cookies (the issue)**: 9 "rejected as third-party" console errors captured; the iframe now shows the interstitial, and after Firefox denies storage access the user gets actionable guidance instead of a dead preview.
    [firefox_etp_blocked_interstitial_and_guidance.mp4](https://cursor.com/agents/bc-79191563-eaa7-4386-9ed4-54ed153201a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirefox_etp_blocked_interstitial_and_guidance.mp4)
  - **Chromium, third-party cookies blocked with the partitioned jar unavailable** (Partitioned attribute stripped by a proxy to emulate the issue's semantics on an engine whose storage-access prompt is automatable): clicking "Allow preview cookies" recovers the preview end-to-end — probe, 401 header retry, activated cookies, `draftMode: ENABLED`.
    [chromium_blocked_cookies_click_allow_recovery_to_draft_mode.mp4](https://cursor.com/agents/bc-79191563-eaa7-4386-9ed4-54ed153201a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchromium_blocked_cookies_click_allow_recovery_to_draft_mode.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79191563-eaa7-4386-9ed4-54ed153201a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79191563-eaa7-4386-9ed4-54ed153201a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

