### PR TITLE
fix(image): type the ref prop, pass data:/blob: srcs through, stega-clean src

### DIFF
--- a/.changeset/image-data-blob-passthrough.md
+++ b/.changeset/image-data-blob-passthrough.md
@@ -1,0 +1,5 @@
+---
+'next-sanity': patch
+---
+
+fix(image): pass `data:` and `blob:` srcs through untouched. They render unoptimized, like in `next/image`, instead of being corrupted by appended CDN params.

--- a/.changeset/image-ref-typing.md
+++ b/.changeset/image-ref-typing.md
@@ -1,0 +1,5 @@
+---
+'next-sanity': patch
+---
+
+fix(image): type the `ref` prop on `Image`. It was already forwarded to the underlying `<img>` element at runtime, but TypeScript rejected it.

--- a/.changeset/image-stega-clean.md
+++ b/.changeset/image-stega-clean.md
@@ -1,0 +1,5 @@
+---
+'next-sanity': patch
+---
+
+fix(image): strip stega-encoded metadata from `src` in `Image` and `imageLoader`, so custom `stega.filter` setups that encode URLs can't corrupt CDN requests.

--- a/packages/next-sanity/src/image/Image.tsx
+++ b/packages/next-sanity/src/image/Image.tsx
@@ -1,3 +1,4 @@
+import {stegaClean} from '@sanity/client/stega'
 import NextImage, {type ImageProps as NextImageProps} from 'next/image'
 
 import {imageLoader} from './imageLoader'
@@ -12,8 +13,13 @@ export interface ImageProps extends Omit<NextImageProps, 'loader' | 'src'> {
   loader?: never
   /**
    * Must be a string that is a valid URL to an image on the Sanity Image CDN.
+   * Stega-encoded metadata from Content Source Maps is stripped automatically.
    */
   src: string
+  /**
+   * A ref to the underlying `<img>` element, forwarded through `next/image`.
+   */
+  ref?: React.ComponentProps<typeof NextImage>['ref']
 }
 
 /**
@@ -26,19 +32,26 @@ export function Image(props: ImageProps): React.JSX.Element {
       'The `loader` prop is not supported on `Image` components. Use `next/image` directly to use a custom loader.',
     )
   }
+  const cleanSrc = stegaClean(src)
+  // data: and blob: URLs can't point to the Sanity Image CDN and don't support
+  // transformation params: pass them through untouched and let `next/image`
+  // render them unoptimized.
+  if (cleanSrc.startsWith('data:') || cleanSrc.startsWith('blob:')) {
+    return <NextImage {...rest} src={cleanSrc} loader={imageLoader} />
+  }
   let srcUrl: URL
   try {
-    srcUrl = new URL(src)
-    if (props.height) {
-      srcUrl.searchParams.set('h', `${props.height}`)
-    }
-    if (props.width) {
-      srcUrl.searchParams.set('w', `${props.width}`)
-    }
+    srcUrl = new URL(cleanSrc)
   } catch (err) {
     throw new TypeError('The `src` prop must be a valid URL to an image on the Sanity Image CDN.', {
       cause: err,
     })
+  }
+  if (props.height) {
+    srcUrl.searchParams.set('h', `${props.height}`)
+  }
+  if (props.width) {
+    srcUrl.searchParams.set('w', `${props.width}`)
   }
   return <NextImage {...rest} src={srcUrl.toString()} loader={imageLoader} />
 }

--- a/packages/next-sanity/src/image/imageLoader.ts
+++ b/packages/next-sanity/src/image/imageLoader.ts
@@ -1,10 +1,11 @@
+import {stegaClean} from '@sanity/client/stega'
 import type {ImageLoader} from 'next/image'
 
 /**
  * @alpha
  */
 export const imageLoader: ImageLoader = ({src, width, quality}) => {
-  const url = new URL(src)
+  const url = new URL(stegaClean(src))
   url.searchParams.set('auto', 'format')
   if (!url.searchParams.has('fit')) {
     url.searchParams.set('fit', url.searchParams.has('h') ? 'min' : 'max')

--- a/packages/next-sanity/test/Image.browser.test.tsx
+++ b/packages/next-sanity/test/Image.browser.test.tsx
@@ -148,20 +148,10 @@ describe('preload', () => {
 })
 
 describe('refs', () => {
-  test('forwards ref to the underlying <img> element at runtime, but the prop is not typed', async () => {
+  test('forwards ref to the underlying <img> element', async () => {
     const ref = createRef<HTMLImageElement>()
     await render(
-      <Image
-        // @ts-expect-error -- `ImageProps` does not accept `ref` because the
-        // next/image props type omits it. next/image itself re-adds it via
-        // forwardRef, so it works at runtime; typing it is a candidate for a
-        // future ergonomics improvement.
-        ref={ref}
-        src={sanityImageUrl('ref-2000x1000.jpg')}
-        width={800}
-        height={400}
-        alt=""
-      />,
+      <Image ref={ref} src={sanityImageUrl('ref-2000x1000.jpg')} width={800} height={400} alt="" />,
     )
 
     expect(ref.current).toBeInstanceOf(HTMLImageElement)

--- a/packages/next-sanity/test/Image.test.tsx
+++ b/packages/next-sanity/test/Image.test.tsx
@@ -13,8 +13,10 @@
  * the vercel/next.js repo (test/unit/next-image-new.test.ts and
  * test/integration/image-component/*) and its image-component demo app.
  */
+import {vercelStegaCombine} from '@vercel/stega'
 import {Image, imageLoader, type ImageProps} from 'next-sanity/image'
 import NextImage, {getImageProps, type ImageProps as NextImageProps} from 'next/image'
+import type {ComponentProps} from 'react'
 import {afterEach, describe, expect, expectTypeOf, test, vi} from 'vitest'
 
 import {
@@ -211,6 +213,38 @@ describe('src URL construction', () => {
     for (const candidate of parseSrcSet(img.srcset)) {
       expect(candidate.params.fit).toBe('crop')
     }
+  })
+
+  test('strips stega-encoded metadata from the src', async () => {
+    // Content Source Maps embed invisible characters into strings. The
+    // default stega filter skips URLs (which is why `skip: false` is forced
+    // here), but custom `stega.filter` setups can encode them, which would
+    // corrupt the CDN request
+    const src = sanityImageUrl('stega-2000x1000.jpg')
+    const encoded = vercelStegaCombine(src, {origin: 'sanity.io', href: '/studio'}, false)
+    expect(encoded).not.toBe(src)
+
+    const {img} = await renderImage(<Image src={encoded} width={800} height={400} alt="" />)
+
+    expect(img.src).toBe(`${src}?h=960&w=1920&auto=format&fit=min`)
+  })
+
+  test('passes data: URLs through untouched, rendered unoptimized by next/image', async () => {
+    const src = 'data:image/png;base64,SGVsbG8='
+    const {img} = await renderImage(<Image src={src} width={800} height={400} alt="" />)
+
+    expect(img.src).toBe(src)
+    expect(img.srcset).toBeUndefined()
+    // data: URLs also disable lazy loading
+    expect(img.loading).toBeUndefined()
+  })
+
+  test('passes blob: URLs through untouched, rendered unoptimized by next/image', async () => {
+    const src = 'blob:https://example.com/9115d58c-bcda-ff47-86e5-083e9a2bcdbf'
+    const {img} = await renderImage(<Image src={src} width={800} height={400} alt="" />)
+
+    expect(img.src).toBe(src)
+    expect(img.srcset).toBeUndefined()
   })
 
   test('throws a TypeError for a relative src, unlike next/image which supports them', async () => {
@@ -823,20 +857,6 @@ describe('documented quirks', () => {
     expect(img.srcset).toBeDefined()
     expect(searchParamsOf(img.src)).toMatchObject({auto: 'format', w: '1920'})
   })
-
-  test('data: URLs render unoptimized, but the appended w/h params corrupt the payload', async () => {
-    // next/image renders data: URLs as-is (unoptimized), but the wrapper
-    // unconditionally appends w/h params to the URL. Sanity CDN URLs are the
-    // only supported src, so this documents what happens with invalid input.
-    const {img} = await renderImage(
-      <Image src="data:image/png;base64,SGVsbG8=" width={800} height={400} alt="" />,
-    )
-
-    expect(img.src).toBe('data:image/png;base64,SGVsbG8=?h=400&w=800')
-    expect(img.srcset).toBeUndefined()
-    // data: URLs also disable lazy loading
-    expect(img.loading).toBeUndefined()
-  })
 })
 
 describe('composing imageLoader with getImageProps', () => {
@@ -899,9 +919,13 @@ describe('type-level contract with next/image', () => {
     expectTypeOf<Required<ImageProps>['loader']>().toBeNever()
   })
 
+  test('ref is typed the same way next/image accepts it', () => {
+    expectTypeOf<ImageProps['ref']>().toEqualTypeOf<ComponentProps<typeof NextImage>['ref']>()
+  })
+
   test('every other next/image prop is accepted unchanged', () => {
-    expectTypeOf<Omit<ImageProps, 'src' | 'loader'>>().toEqualTypeOf<
-      Omit<NextImageProps, 'src' | 'loader'>
+    expectTypeOf<Omit<ImageProps, 'src' | 'loader' | 'ref'>>().toEqualTypeOf<
+      Omit<NextImageProps, 'src' | 'loader' | 'ref'>
     >()
   })
 })

--- a/packages/next-sanity/test/imageLoader.test.ts
+++ b/packages/next-sanity/test/imageLoader.test.ts
@@ -1,3 +1,4 @@
+import {vercelStegaCombine} from '@vercel/stega'
 import {imageLoader} from 'next-sanity/image'
 import {expect, test} from 'vitest'
 
@@ -182,4 +183,15 @@ test('throws a TypeError for relative URLs', () => {
   expect(() =>
     imageLoader({src: '/images/local.jpg', width: 800, quality: undefined}),
   ).toThrowError(TypeError)
+})
+
+test('strips stega-encoded metadata from the src', () => {
+  const src = 'https://cdn.sanity.io/images/project/dataset/image.jpg'
+  const result = imageLoader({
+    src: vercelStegaCombine(src, {origin: 'sanity.io', href: '/studio'}, false),
+    width: 800,
+    quality: undefined,
+  })
+
+  expect(result).toBe(`${src}?auto=format&fit=max&w=800`)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #3924 (comprehensive test coverage). First of three PRs acting on the findings from that test suite — this one polishes the existing `next-sanity/image` surface without changing its shape.

## Changes

1. **`ref` is now typed.** `next/image` forwards refs to the underlying `<img>` element and our wrapper already passed them through at runtime, but `ImageProps` (derived from the `next/image` props type, which omits `ref`) rejected them at the type level. The prop is now typed exactly as `next/image` accepts it (`ComponentProps<typeof NextImage>['ref']`), and the browser test that documented the gap with a `@ts-expect-error` now exercises the typed prop.

2. **`data:` and `blob:` srcs pass through untouched.** The wrapper unconditionally appended `w`/`h` CDN params, corrupting `data:` payloads (documented as a quirk in #3924). These URLs can't point at the Sanity CDN and don't support transformation params, so they now pass through unchanged and render unoptimized — the same behavior as plain `next/image`.

3. **Stega metadata is stripped from `src`.** Content Source Maps embed invisible characters into query result strings. The default stega filter skips URL-shaped values, but custom `stega.filter` setups can encode them — and those characters end up percent-encoded into the CDN request, breaking the image. Both `Image` and `imageLoader` now run the src through `stegaClean` (a tiny standalone chunk of `@sanity/client`, already a dependency).

## Tests

All behavior changes are pinned by updates to the suite from #3924: the `data:` corruption quirk test became a passthrough feature test (plus a new `blob:` test), stega-stripping tests cover both the component and the standalone loader (using `@vercel/stega` to force-encode a URL), and the type-level contract tests assert the `ref` typing.

`vitest run`: 15 files, 272 passed / 12 skipped. Type-aware `oxlint`, build + publint all clean.

Includes one changeset per fix (all `patch`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f478bb00-8222-43d9-a9fd-95fb01165d8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f478bb00-8222-43d9-a9fd-95fb01165d8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

