### PR TITLE
feat(image): infer width and height from the Sanity CDN URL

### DIFF
--- a/.changeset/image-intrinsic-dimensions.md
+++ b/.changeset/image-intrinsic-dimensions.md
@@ -1,0 +1,5 @@
+---
+'next-sanity': minor
+---
+
+feat(image): infer `width` and `height` from the Sanity CDN URL. `<Image src={url} alt="" />` now renders without explicit dimensions: they resolve from the URL's `w`/`h` params (e.g. set by an `@sanity/image-url` builder), its `rect` crop param, or the original dimensions Sanity encodes into every asset filename. Providing only one dimension derives the other from the image's aspect ratio, like `next/image` does for static imports.

--- a/packages/next-sanity/src/image/Image.tsx
+++ b/packages/next-sanity/src/image/Image.tsx
@@ -2,6 +2,7 @@ import {stegaClean} from '@sanity/client/stega'
 import NextImage, {type ImageProps as NextImageProps} from 'next/image'
 
 import {imageLoader} from './imageLoader'
+import {resolveImageDimensions} from './resolveImageDimensions'
 
 /**
  * @alpha
@@ -23,6 +24,15 @@ export interface ImageProps extends Omit<NextImageProps, 'loader' | 'src'> {
 }
 
 /**
+ * Renders an image from the Sanity Image CDN with `next/image`.
+ *
+ * Unlike `next/image`, `width` and `height` are optional: when omitted they
+ * are inferred from the URL, in order of precedence, from its `w`/`h` params
+ * (e.g. set by an `@sanity/image-url` builder), its `rect` crop param, or the
+ * original dimensions Sanity encodes in every asset filename. Providing only
+ * one dimension derives the other from the image's aspect ratio, like
+ * `next/image` does for static imports.
+ *
  * @alpha
  */
 export function Image(props: ImageProps): React.JSX.Element {
@@ -47,11 +57,22 @@ export function Image(props: ImageProps): React.JSX.Element {
       cause: err,
     })
   }
-  if (props.height) {
-    srcUrl.searchParams.set('h', `${props.height}`)
+  const {width, height} = resolveImageDimensions(srcUrl, props.width, props.height, props.fill)
+  // Encoding the resolved dimensions as CDN params lets the loader scale
+  // both axes proportionally for every srcset candidate.
+  if (height) {
+    srcUrl.searchParams.set('h', `${height}`)
   }
-  if (props.width) {
-    srcUrl.searchParams.set('w', `${props.width}`)
+  if (width) {
+    srcUrl.searchParams.set('w', `${width}`)
   }
-  return <NextImage {...rest} src={srcUrl.toString()} loader={imageLoader} />
+  return (
+    <NextImage
+      {...rest}
+      width={width}
+      height={height}
+      src={srcUrl.toString()}
+      loader={imageLoader}
+    />
+  )
 }

--- a/packages/next-sanity/src/image/resolveImageDimensions.ts
+++ b/packages/next-sanity/src/image/resolveImageDimensions.ts
@@ -1,0 +1,79 @@
+type Dimension = number | `${number}`
+
+interface ResolvedDimensions {
+  width: Dimension | undefined
+  height: Dimension | undefined
+}
+
+/**
+ * Sanity encodes the original dimensions of every image asset into its
+ * filename, e.g. `…/Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000.jpg`.
+ */
+const FILENAME_DIMENSIONS = /-(\d+)x(\d+)\.\w+$/
+
+function parsePositiveInt(value: string | null | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+/**
+ * The intrinsic dimensions of the image a Sanity CDN URL points at: the
+ * `rect` crop region when present (what the CDN will actually serve),
+ * otherwise the original dimensions encoded in the asset filename.
+ */
+function intrinsicDimensionsOf(srcUrl: URL): {width: number; height: number} | undefined {
+  const rect = srcUrl.searchParams.get('rect')?.split(',')
+  if (rect?.length === 4) {
+    const width = parsePositiveInt(rect[2])
+    const height = parsePositiveInt(rect[3])
+    if (width && height) return {width, height}
+  }
+  const filename = FILENAME_DIMENSIONS.exec(srcUrl.pathname)
+  if (filename) {
+    const width = parsePositiveInt(filename[1])
+    const height = parsePositiveInt(filename[2])
+    if (width && height) return {width, height}
+  }
+  return undefined
+}
+
+/**
+ * Resolves the display dimensions for an image, in order of precedence:
+ *
+ * 1. The `width` and `height` props.
+ * 2. The `w` and `h` params on the src URL (e.g. from an `@sanity/image-url`
+ *    builder).
+ * 3. Derived from the image's intrinsic aspect ratio, when only one dimension
+ *    is known.
+ * 4. The intrinsic dimensions: the `rect` crop region when present, otherwise
+ *    the original dimensions Sanity encodes in the asset filename.
+ *
+ * `fill` images have no display dimensions, so resolution is skipped.
+ */
+export function resolveImageDimensions(
+  srcUrl: URL,
+  propWidth: Dimension | undefined,
+  propHeight: Dimension | undefined,
+  fill: boolean | undefined,
+): ResolvedDimensions {
+  if (fill) {
+    return {width: propWidth, height: propHeight}
+  }
+  const width = propWidth ?? parsePositiveInt(srcUrl.searchParams.get('w'))
+  const height = propHeight ?? parsePositiveInt(srcUrl.searchParams.get('h'))
+  if (width !== undefined && height !== undefined) {
+    return {width, height}
+  }
+  const intrinsic = intrinsicDimensionsOf(srcUrl)
+  if (!intrinsic) {
+    return {width, height}
+  }
+  if (width !== undefined) {
+    return {width, height: Math.round((Number(width) / intrinsic.width) * intrinsic.height)}
+  }
+  if (height !== undefined) {
+    return {width: Math.round((Number(height) / intrinsic.height) * intrinsic.width), height}
+  }
+  return intrinsic
+}

--- a/packages/next-sanity/test/Image.test.tsx
+++ b/packages/next-sanity/test/Image.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Comprehensive coverage of how `next-sanity/image` drives `next/image`.
  *
- * `<Image>` is a thin wrapper: it encodes the `width`/`height` props as `w`/`h`
- * params on the Sanity CDN URL, then delegates rendering to `next/image` with
- * `imageLoader` as the `loader`. That means the rendered `<img>` markup is
- * produced by `next/image` itself, so these tests pin down the full contract:
+ * `<Image>` is a thin wrapper: it resolves the display dimensions (from props,
+ * URL params or the intrinsic dimensions Sanity encodes into asset filenames),
+ * encodes them as `w`/`h` params on the Sanity CDN URL, then delegates
+ * rendering to `next/image` with `imageLoader` as the `loader`. That means the
+ * rendered `<img>` markup is produced by `next/image` itself, so these tests
+ * pin down the full contract:
  * which of the many `next/image` options work through the wrapper, what URLs
  * the loader generates for each `srcset` candidate, and which dev-mode
  * validations still fire.
@@ -356,6 +358,100 @@ describe('srcset and sizes', () => {
 
     const candidates = parseSrcSet(img.srcset)
     expect(img.src).toBe(candidates.at(-1)?.url)
+  })
+})
+
+describe('intrinsic dimensions', () => {
+  test('a bare CDN URL renders with the dimensions encoded in the asset filename', async () => {
+    const src = sanityImageUrl('bare-2000x1000.jpg')
+    const {img} = await renderImage(<Image src={src} alt="" />)
+
+    expect(img.width).toBe('2000')
+    expect(img.height).toBe('1000')
+    // The inferred dimensions are encoded as CDN params too, so every srcset
+    // candidate keeps the aspect ratio
+    expect(
+      parseSrcSet(img.srcset).map(
+        ({descriptor, params}) => `${params.w}x${params.h} ${descriptor}`,
+      ),
+    ).toEqual(['2048x1024 1x', '3840x1920 2x'])
+  })
+
+  test('height is derived from the aspect ratio when only width is set', async () => {
+    const src = sanityImageUrl('derive-h-2000x1000.jpg')
+    const {img} = await renderImage(<Image src={src} width={800} alt="" />)
+
+    expect(img.width).toBe('800')
+    expect(img.height).toBe('400')
+  })
+
+  test('width is derived from the aspect ratio when only height is set', async () => {
+    const src = sanityImageUrl('derive-w-2000x1000.jpg')
+    const {img} = await renderImage(<Image src={src} height={250} alt="" />)
+
+    expect(img.width).toBe('500')
+    expect(img.height).toBe('250')
+  })
+
+  test('w/h params from an @sanity/image-url builder are used as the display dimensions', async () => {
+    // urlFor(image).width(500).height(250).url()
+    const src = sanityImageUrl('built-2000x1000.jpg', '?w=500&h=250')
+    const {img} = await renderImage(<Image src={src} alt="" />)
+
+    expect(img.width).toBe('500')
+    expect(img.height).toBe('250')
+    expect(
+      parseSrcSet(img.srcset).map(
+        ({descriptor, params}) => `${params.w}x${params.h} ${descriptor}`,
+      ),
+    ).toEqual(['640x320 1x', '1080x540 2x'])
+  })
+
+  test('a single w param derives the height from the filename aspect ratio', async () => {
+    // urlFor(image).width(500).url()
+    const src = sanityImageUrl('built-w-2000x1000.jpg', '?w=500')
+    const {img} = await renderImage(<Image src={src} alt="" />)
+
+    expect(img.width).toBe('500')
+    expect(img.height).toBe('250')
+  })
+
+  test('the rect crop param takes precedence over the filename dimensions', async () => {
+    // urlFor(image).url() with a crop set in the Studio: the CDN serves the
+    // rect region, so the crop dimensions are the intrinsic dimensions
+    const src = sanityImageUrl('rect-2000x1000.jpg', '?rect=40,20,1000,500')
+    const {img} = await renderImage(<Image src={src} alt="" />)
+
+    expect(img.width).toBe('1000')
+    expect(img.height).toBe('500')
+    for (const candidate of parseSrcSet(img.srcset)) {
+      expect(candidate.params.rect).toBe('40,20,1000,500')
+    }
+  })
+
+  test('a width prop combined with a rect param derives the height from the crop aspect ratio', async () => {
+    const src = sanityImageUrl('rect-derive-3000x3000.jpg', '?rect=0,0,1000,500')
+    const {img} = await renderImage(<Image src={src} width={800} alt="" />)
+
+    expect(img.width).toBe('800')
+    expect(img.height).toBe('400')
+  })
+
+  test('explicit width and height props win over URL params and intrinsic dimensions', async () => {
+    const src = sanityImageUrl('explicit-2000x1000.jpg', '?w=500&h=250&rect=0,0,1000,500')
+    const {img} = await renderImage(<Image src={src} width={100} height={100} alt="" />)
+
+    expect(img.width).toBe('100')
+    expect(img.height).toBe('100')
+  })
+
+  test('inference is skipped for fill images', async () => {
+    const src = sanityImageUrl('fill-skip-2000x1000.jpg')
+    const {img} = await renderImage(<Image src={src} fill alt="" />)
+
+    expect(img.width).toBeUndefined()
+    expect(img.height).toBeUndefined()
+    expect(searchParamsOf(img.src)).toEqual({auto: 'format', fit: 'max', w: '3840'})
   })
 })
 
@@ -746,9 +842,10 @@ describe('other next/image props', () => {
 })
 
 describe('next/image dev-mode validation still applies', () => {
-  test('throws when width and height are missing without fill', async () => {
+  test('throws when dimensions are missing and cannot be inferred from the URL', async () => {
     const error = await renderImageError(
-      <Image src={sanityImageUrl('missing-dims-2000x1000.jpg')} alt="" />,
+      // No w/h params, no rect and no dimensions in the filename
+      <Image src={sanityImageUrl('missing-dims.jpg')} alt="" />,
     )
 
     expect(error).toMatchObject({
@@ -756,9 +853,9 @@ describe('next/image dev-mode validation still applies', () => {
     })
   })
 
-  test('throws when only width is provided', async () => {
+  test('throws when only width is provided and the height cannot be inferred', async () => {
     const error = await renderImageError(
-      <Image src={sanityImageUrl('missing-height-2000x1000.jpg')} width={800} alt="" />,
+      <Image src={sanityImageUrl('missing-height.jpg')} width={800} alt="" />,
     )
 
     expect(error).toMatchObject({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #3925. Second of three ergonomics PRs: `width` and `height` become optional, resolved from information the Sanity CDN URL already carries — the same idea as [`sanity-image`](https://www.npmjs.com/package/sanity-image)'s dimension parsing, adapted to `next/image` semantics.

## What changes

Every Sanity asset filename encodes the original dimensions (`…-2000x1000.jpg`), and URLs built with `@sanity/image-url` carry `w`/`h`/`rect` params. The new `resolveImageDimensions` resolves display dimensions in order of precedence:

1. the `width`/`height` props (unchanged behavior),
2. the URL's `w`/`h` params — so `urlFor(image).width(500).height(250).url()` renders with the dimensions it was built for,
3. deriving the missing axis from the aspect ratio when only one dimension is known — `width={800}` on a 2:1 asset yields `height={400}`, like `next/image` does for static imports,
4. the intrinsic dimensions: the `rect` crop region when present (that's what the CDN actually serves), otherwise the filename dimensions.

So the simplest possible usage now works, with correct layout-shift-free attributes:

```tsx
<Image src={post.mainImageUrl} alt="" />
```

Resolved dimensions are also encoded as CDN params, so every srcset candidate keeps the aspect ratio (previously only explicit props got that treatment). `fill` images skip resolution entirely, and URLs with no recoverable dimensions (e.g. no dimension pattern in the filename) fall back to the existing `next/image` dev-mode errors.

## Tests

New `intrinsic dimensions` describe covering each precedence rule, rect-over-filename priority, single-axis derivation (both directions), explicit-props-win, and fill skipping. The two dev-mode validation tests from #3924 that asserted "missing width/height throws" now use dimension-less filenames — the diff on those tests is a precise record of the behavior change.

`vitest run`: 15 files, 281 passed / 12 skipped. Type-aware `oxlint`, build + publint clean. Changeset: `minor`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f478bb00-8222-43d9-a9fd-95fb01165d8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f478bb00-8222-43d9-a9fd-95fb01165d8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

