### PR TITLE
chore: upgrade pnpm to v11.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       matrix:
         # https://nodejs.org/en/about/releases/
         # https://pnpm.io/installation#compatibility
+        # pnpm 11 requires Node.js 22+
+
         # @TODO re-enable `current` once it recovers
         # node: [lts/-1, lts/*, current]
         node: [lts/-1, lts/*]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: lts/*
-      - run: pnpm install --ignore-scripts
+      # Not --ignore-scripts: pnpm 11 fails an install with unapproved dependency
+      # build scripts, and this job is where that should surface.
+      - run: pnpm install
       - run: pnpm build --filter=./packages/*
       - run: pnpm typegen
       - run: pnpm lint --format github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Use the pre-installed nvm Node (v22.22.2) for any build/dev/test work by prepend
 export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
 ```
 
-`nvm use` alone is not enough because `/exec-daemon` sits ahead of nvm's shims in `PATH`. This nvm node also bundles the correct `pnpm` (10.34.5), so prepending it fixes both `node` and `pnpm` in one step. `pnpm install` itself works on the default node; only building/running needs the newer node. `pnpm test:e2e` (Vitest browser project) needs Chromium: `pnpm playwright install chromium`.
+`nvm use` alone is not enough because `/exec-daemon` sits ahead of nvm's shims in `PATH`. This nvm node also bundles a pnpm, but the repo pins pnpm 11 via `packageManager`. Activate that version with Corepack (`corepack enable && corepack prepare`) after prepending nvm. `pnpm install` itself works on the default node; only building/running needs the newer node. `pnpm test:e2e` (Vitest browser project) needs Chromium: `pnpm playwright install chromium`.
 
 ### Demo app env
 

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "knip": "^6.32.2",
     "pkg-pr-new": "^0.0.87"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "pnpm@11.25.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
   '@swc/core': false
   better-sqlite3: false
   esbuild: false
+  msw: false
   onnxruntime-node: false
   protobufjs: false
   sharp: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin the repo to pnpm 11.25.0 (`latest-11`).

Library consumers are unaffected. CI and contributors pick up pnpm 11 through `packageManager` and `pnpm/action-setup`.

**What changed**
- `packageManager` is now `pnpm@11.25.0`.
- `allowBuilds` denies `msw`, which pnpm 11 requires an explicit decision on (see below).
- The CI `build` job installs with scripts instead of `--ignore-scripts`, so an unapproved build script fails there rather than only on Vercel.
- Cloud agent notes tell you to `corepack enable && corepack prepare` after prepending nvm Node.

**What did not change**
- `pnpm-workspace.yaml` was already on the v11 shape (`allowBuilds`, no `package.json#pnpm`, no project `.npmrc`).
- `pnpm-lock.yaml` did not need a rewrite; it stays at `lockfileVersion: 9.0`, which is what pnpm 11 writes.
- The official `pnpm-v10-to-v11` codemod made no edits.

**The Vercel failure on the first push**

The first commit passed all 13 GitHub checks and failed the `Vercel – next-sanity` deployment. pnpm 11 flips `strictDepBuilds` to `true`, so a dependency with an unapproved build script now fails the install instead of warning:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: msw@2.15.0
```

`msw` arrives transitively through `@vitest/browser` and no code here imports it, so its build is denied. Denying the build script does not disable msw: the browser tests still exercise it as a request interceptor.

Every workflow installed with `--ignore-scripts`, which skips this check entirely, and no CI job builds `apps/mvp`. Vercel runs a plain `pnpm install` and builds that app, so it was the only place the failure could appear. Hence the CI change above.

**v11 defaults we are keeping**
- `minimumReleaseAge` (1 day) and `blockExoticSubdeps`. Canary Next and `sanity: next` are pinned in the lockfile, and the supply-chain verification passes.
- Native `pnpm publish` is out of scope. Changesets still publish through npm, so `NPM_CONFIG_PROVENANCE` in release is unchanged.

**Verified locally on pnpm 11.25.0 / Node 22.22.2**
- `pnpm install` (with scripts, as Vercel runs it) succeeds; it fails without the `msw` entry.
- `pnpm --filter mvp build` and `pnpm --filter static build` both succeed. These are the two Vercel projects.
- `pnpm lint`, `pnpm knip`, `pnpm test` (171 unit tests plus fixture builds), and `pnpm test:e2e` (21 browser tests) all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56f5f1ed-7580-4a23-8270-a235ddb24e69?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56f5f1ed-7580-4a23-8270-a235ddb24e69&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

