### PR TITLE
ci: pin release workflow npm to 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,10 @@ jobs:
           cache: pnpm
           check-latest: true
           node-version: lts/*
+      # Pin npm 11: npm 12 wraps `info --json` in an array; @changesets/cli@3.0.1's
+      # pnpm parser does not unwrap it (changesets/changesets#2274). Trusted publishing needs npm >= 11.5.1.
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release on main is crashing. The workflow installs `npm@latest`, which is now 12. `pnpm info --json` then returns an array-wrapped packument. `@changesets/cli@3.0.1` unwraps that in the npm parser but not the pnpm parser ([changesets/changesets#2274](https://github.com/changesets/changesets/issues/2274)), so `getUnpublishedPackages` calls `.includes` on undefined.

Trusted publishing only needs npm >= 11.5.1. Pin the install to `npm@11` until changesets ships a fix.

Failing run: https://github.com/sanity-io/next-sanity/actions/runs/33496342128/job/99819318096

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-081e6489-6a26-497c-ba72-8cb047e3d1c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-081e6489-6a26-497c-ba72-8cb047e3d1c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

