### PR TITLE
test(live): cover the events request SanityLive makes and the tags sanityFetch returns

### DIFF
--- a/packages/next-sanity/test/SanityLive.browser.test.tsx
+++ b/packages/next-sanity/test/SanityLive.browser.test.tsx
@@ -1,3 +1,5 @@
+import {http} from 'msw'
+import type {SetupWorker} from 'msw/browser'
 import {createClient} from 'next-sanity'
 import {Component, type ReactNode} from 'react'
 import {beforeEach, describe, expect, vi} from 'vitest'
@@ -116,6 +118,92 @@ describe('SanityLiveClientComponent', () => {
     await vi.waitUntil(() => onWelcome.mock.calls.length > 0 || onError.mock.calls.length > 0)
     expect(onError).not.toHaveBeenCalled()
     expect(onWelcome).toHaveBeenCalled()
+  })
+
+  describe('events request', () => {
+    const eventsUrl = 'https://*.api.sanity.io/:apiVersion/data/live/events/:dataset'
+
+    /**
+     * Records the request the browser makes for the event stream. Returning
+     * `undefined` hands the request on to the SSE handler, so the component
+     * still gets its `welcome` and the test can wait on `onWelcome`.
+     */
+    function captureEventsRequest(worker: SetupWorker) {
+      const requests: Request[] = []
+      worker.use(
+        http.get(eventsUrl, ({request}) => {
+          requests.push(request)
+          return undefined
+        }),
+      )
+      return requests
+    }
+
+    test('connects to the API host for the configured dataset and version', async ({worker}) => {
+      const requests = captureEventsRequest(worker)
+      try {
+        const onWelcome = vi.fn()
+        await renderMock({onWelcome})
+        await vi.waitFor(() => expect(onWelcome).toHaveBeenCalled())
+
+        const [request] = requests
+        const url = new URL(request.url)
+        expect(url.origin).toBe(`https://${projectId}.api.sanity.io`)
+        expect(url.pathname).toBe(`/v${apiVersion}/data/live/events/${dataset}`)
+        expect(url.searchParams.get('tag')).toBe('next-loader.live')
+        expect(url.searchParams.has('includeDrafts')).toBe(false)
+        expect(url.searchParams.has('waitFor')).toBe(false)
+        expect(request.headers.has('authorization')).toBe(false)
+      } finally {
+        worker.resetHandlers()
+      }
+    })
+
+    test('includeDrafts sends the browser token and asks for drafts', async ({worker}) => {
+      const requests = captureEventsRequest(worker)
+      try {
+        const onWelcome = vi.fn()
+        await renderMock({onWelcome, includeDrafts: true}, {token: 'sk123'})
+        await vi.waitFor(() => expect(onWelcome).toHaveBeenCalled())
+
+        const [request] = requests
+        expect(new URL(request.url).searchParams.get('includeDrafts')).toBe('true')
+        expect(request.headers.get('authorization')).toBe('Bearer sk123')
+        // Handlers receive the same context, so they can tell drafts apart.
+        expect(onWelcome.mock.lastCall?.[1]).toEqual({includeDrafts: true, waitFor: undefined})
+      } finally {
+        worker.resetHandlers()
+      }
+    })
+
+    test('waitFor="function" is forwarded to the event stream', async ({worker}) => {
+      const requests = captureEventsRequest(worker)
+      try {
+        const onWelcome = vi.fn()
+        await renderMock({onWelcome, waitFor: 'function'})
+        await vi.waitFor(() => expect(onWelcome).toHaveBeenCalled())
+
+        const [request] = requests
+        expect(new URL(request.url).searchParams.get('waitFor')).toBe('function')
+        expect(onWelcome.mock.lastCall?.[1]).toEqual({includeDrafts: false, waitFor: 'function'})
+      } finally {
+        worker.resetHandlers()
+      }
+    })
+
+    test('requestTag is prefixed with the client requestTagPrefix', async ({worker}) => {
+      const requests = captureEventsRequest(worker)
+      try {
+        const onWelcome = vi.fn()
+        await renderMock({onWelcome, requestTag: 'live'}, {requestTagPrefix: 'storefront'})
+        await vi.waitFor(() => expect(onWelcome).toHaveBeenCalled())
+
+        const [request] = requests
+        expect(new URL(request.url).searchParams.get('tag')).toBe('storefront.live')
+      } finally {
+        worker.resetHandlers()
+      }
+    })
   })
 
   describe('action', () => {

--- a/packages/next-sanity/test/helpers.browser.ts
+++ b/packages/next-sanity/test/helpers.browser.ts
@@ -1,8 +1,9 @@
+import type {SetupWorker} from 'msw/browser'
 import {test as testBase} from 'vitest'
 
 import {worker} from './mocks/browser'
 
-export const test = testBase.extend({
+export const test = testBase.extend<{worker: SetupWorker}>({
   worker: [
     // oxlint-disable-next-line no-empty-pattern
     async ({}, next) => {

--- a/packages/next-sanity/test/sanityFetch.test.ts
+++ b/packages/next-sanity/test/sanityFetch.test.ts
@@ -102,9 +102,33 @@ describe.each([{cacheComponents: true}, {cacheComponents: false}])(
 
         // Then prove that the sanityFetch wrapper works correctly
         const {data, sourceMap, tags} = await sanityFetch({query, params})
-        expect(tags.length).toBe(1)
+        expect(tags).toEqual(['sanity:A'])
         expect(sourceMap).toBeNull()
         expect(data).toEqual(params)
+      })
+    })
+
+    describe('tags', () => {
+      const client = createClient({projectId, dataset, apiVersion, useCdn: true})
+      const {sanityFetch} = defineLive({client, browserToken: false, serverToken: false})
+      const {query, params} = getSanityFetchMock(
+        '{"perspective": $perspective, "useCdn": $useCdn}',
+        {
+          perspective: 'published',
+          useCdn: true,
+        },
+      )
+
+      test('returns the sync tags of the query with the cache tag prefix', async () => {
+        // The prefix is what `<SanityLive />` adds to the tags of a live event
+        // before revalidating, so the two have to agree.
+        const {tags} = await sanityFetch({query, params})
+        expect(tags).toEqual(['sanity:A'])
+      })
+
+      test('keeps custom tags ahead of the sync tags', async () => {
+        const {tags} = await sanityFetch({query, params, tags: ['home', 'posts']})
+        expect(tags).toEqual(['home', 'posts', 'sanity:A'])
       })
     })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds coverage for what a consumer can observe from `<SanityLive />` and `sanityFetch` when they talk to the Live Content API. Tests only, no runtime change.

## What is covered now

The event stream request, recorded in the browser suite with a pass-through MSW handler in front of the existing SSE mock.

- The client component connects to the project's API host at `/v<apiVersion>/data/live/events/<dataset>`, tagged `next-loader.live`, with no `Authorization` header and neither `includeDrafts` nor `waitFor` set by default.
- `includeDrafts` sends the browser token as `Authorization: Bearer <token>` and adds `includeDrafts=true`. `onWelcome` receives `{includeDrafts: true, waitFor: undefined}` as its context.
- `waitFor="function"` is forwarded as `waitFor=function`, and `onWelcome` receives it in its context.
- `requestTag` is combined with the client's `requestTagPrefix` into `tag=<prefix>.<requestTag>`.

`sanityFetch` tags, in the unit suite.

- The `tags` it returns are the query's sync tags with the `sanity:` cache tag prefix, the same prefix `<SanityLive />` puts on the tags of a live event before revalidating. The existing perspective test asserted only the count and now asserts the value.
- Custom `tags` passed to `sanityFetch` come before the sync tags.

## Test helper change

`test/helpers.browser.ts` now types the `worker` fixture as `SetupWorker`. It was inferred as `unknown`, which kept tests from calling `worker.use()`.

## Not covered on purpose

Nothing here asserts the `reason` of a `goaway` event. `@sanity/client` currently emits it as `data.reason` while its `LiveEventGoAway` type declares `reason` at the top level, so the default handler logs `undefined` (visible in this suite's console output today). That needs a fix in the client first.

## Verification

`pnpm vitest run --project unit` and `pnpm vitest run --project browser` in `packages/next-sanity` (Chromium), plus `pnpm lint` at the root.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe5e882f-9107-41d5-8054-697780d69a93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe5e882f-9107-41d5-8054-697780d69a93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

