### PR TITLE
feat(static-params): add defineGenerateStaticParams driven by the page query

### DIFF
--- a/.changeset/generate-static-params.md
+++ b/.changeset/generate-static-params.md
@@ -4,7 +4,7 @@
 
 Add `next-sanity/static-params` with `defineGenerateStaticParams` and `ensureStaticParams`.
 
-Cache Components fails `next build` when `generateStaticParams` returns `[]`, and a typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the route module loads, so the build fails on the offending expression and its position. At build time it fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
+Cache Components fails `next build` when `generateStaticParams` returns `[]`. A typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the route module loads, so the build fails on the offending expression and its position. At build time it fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
 
 Before:
 
@@ -32,4 +32,4 @@ export const {generateStaticParams} = defineGenerateStaticParams({
 })
 ```
 
-The `fallback` shape types the result: a `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment. Nested segments receive the parent params as GROQ variables, so `app/[category]/[slug]/page.tsx` can filter on `$category`. Handle the placeholder in the page with `notFound()`.
+The `fallback` shape types the result. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment. Nested segments receive the parent params as GROQ variables, so `app/[category]/[slug]/page.tsx` can filter on `$category`. Handle the placeholder in the page with `notFound()`.

--- a/.changeset/generate-static-params.md
+++ b/.changeset/generate-static-params.md
@@ -4,7 +4,7 @@
 
 Add `next-sanity/static-params` with `defineGenerateStaticParams` and `ensureStaticParams`.
 
-Cache Components fails `next build` when `generateStaticParams` returns `[]`, and a typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param, parses every piece with `groq-js` when the route module loads so the build fails on the offending expression and its position, fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
+Cache Components fails `next build` when `generateStaticParams` returns `[]`, and a typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the route module loads, so the build fails on the offending expression and its position. At build time it fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
 
 Before:
 

--- a/.changeset/generate-static-params.md
+++ b/.changeset/generate-static-params.md
@@ -1,0 +1,35 @@
+---
+"next-sanity": minor
+---
+
+Add `next-sanity/static-params` with `defineGenerateStaticParams` and `ensureStaticParams`.
+
+Cache Components fails `next build` when `generateStaticParams` returns `[]`, and a typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param, parses every piece with `groq-js` when the route module loads so the build fails on the offending expression and its position, fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
+
+Before:
+
+```ts
+export async function generateStaticParams() {
+  const {data} = await sanityFetchStaticParams({
+    query: `*[_type == "post" && defined(slug.current)]{"slug": slug.current}`,
+  })
+  return data.length > 0 ? data : [{slug: "__placeholder__"}]
+}
+```
+
+After:
+
+```ts
+import {defineGenerateStaticParams} from "next-sanity/static-params"
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "post" && defined(slug.current)',
+  params: {slug: "slug.current"},
+  fallback: {slug: "__placeholder__"},
+  order: "_updatedAt desc",
+  limit: 100,
+})
+```
+
+The `fallback` shape types the result: a `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment. Nested segments receive the parent params as GROQ variables, so `app/[category]/[slug]/page.tsx` can filter on `$category`. Handle the placeholder in the page with `notFound()`.

--- a/.changeset/generate-static-params.md
+++ b/.changeset/generate-static-params.md
@@ -2,34 +2,43 @@
 "next-sanity": minor
 ---
 
-Add `next-sanity/static-params` with `defineGenerateStaticParams` and `ensureStaticParams`.
+Add `next-sanity/static-params` with `defineGenerateStaticParams`, `ensureStaticParams`, and `STATIC_PARAMS_PLACEHOLDER`.
 
-Cache Components fails `next build` when `generateStaticParams` returns `[]`. A typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the route module loads, so the build fails on the offending expression and its position. At build time it fetches published documents, drops rows with `null` or mistyped values, and returns `[fallback]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
+Cache Components fails `next build` when `generateStaticParams` returns `[]`. A typo in the GROQ that lists your slugs used to surface as an opaque network error deep in the build. `defineGenerateStaticParams` takes the page's own query. It parses it with `groq-js` when the route module loads and reads the root `*[...]` filter. Each `<expression> == $param` conjunct becomes a route param, the other conjuncts stay as constraints, and the `[0]`, slices, `order()`, and projection are dropped. A syntax error, a `$param` that is not bound with `==`, or a query without bindings fails the build with the offending expression. At build time it fetches published documents, drops rows with `null` or mistyped values, and returns `[{slug: STATIC_PARAMS_PLACEHOLDER}]` instead of an empty array. `ensureStaticParams` is the fallback rule on its own for hand-written queries.
 
 Before:
 
 ```ts
+const postQuery = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title}`)
+
 export async function generateStaticParams() {
   const {data} = await sanityFetchStaticParams({
     query: `*[_type == "post" && defined(slug.current)]{"slug": slug.current}`,
   })
   return data.length > 0 ? data : [{slug: "__placeholder__"}]
 }
+
+export default async function Page({params}: PageProps<"/posts/[slug]">) {
+  const {slug} = await params
+  if (slug === "__placeholder__") notFound()
+  // ...
+}
 ```
 
 After:
 
 ```ts
-import {defineGenerateStaticParams} from "next-sanity/static-params"
+import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from "next-sanity/static-params"
 
-export const {generateStaticParams} = defineGenerateStaticParams({
-  client,
-  filter: '_type == "post" && defined(slug.current)',
-  params: {slug: "slug.current"},
-  fallback: {slug: "__placeholder__"},
-  order: "_updatedAt desc",
-  limit: 100,
-})
+const postQuery = defineQuery(`*[_type == "post" && slug.current == $slug][0]{title}`)
+
+export const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
+
+export default async function Page({params}: PageProps<"/posts/[slug]">) {
+  const {slug} = await params
+  if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
+  // ...
+}
 ```
 
-The `fallback` shape types the result. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment. Nested segments receive the parent params as GROQ variables, so `app/[category]/[slug]/page.tsx` can filter on `$category`. Handle the placeholder in the page with `notFound()`.
+Pass `order` and `limit` to prerender only the most recent documents. A nested segment such as `app/[category]/[slug]/page.tsx` receives the parent's params from Next.js, and a binding the parent already provides becomes a GROQ constraint instead of a generated param. A catch-all segment needs `fallback: {path: [STATIC_PARAMS_PLACEHOLDER]}`, because the query cannot tell `[slug]` from `[...slug]`. The result type defaults to `Record<string, string>[]` and takes a generic, `defineGenerateStaticParams<{slug: string}>(...)`, when you want it narrower.

--- a/apps/mvp/app/(website)/posts/[slug]/loading.tsx
+++ b/apps/mvp/app/(website)/posts/[slug]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <article aria-busy className="mx-auto max-w-2xl px-4 py-16">
+      <p className="text-gray-500">Loading…</p>
+    </article>
+  )
+}

--- a/apps/mvp/app/(website)/posts/[slug]/page.tsx
+++ b/apps/mvp/app/(website)/posts/[slug]/page.tsx
@@ -1,22 +1,20 @@
 import {defineQuery} from 'next-sanity'
-import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from 'next-sanity/static-params'
 import Link from 'next/link'
 import {notFound} from 'next/navigation'
 
 import {client} from '@/app/sanity.client'
 
-export const {generateStaticParams} = defineGenerateStaticParams({
-  client,
-  filter: '_type == "post" && defined(slug.current)',
-  params: {slug: 'slug.current'},
-  fallback: {slug: '__placeholder__'},
-  order: '_updatedAt desc',
-  limit: 100,
-})
-
 const postQuery = defineQuery(
   `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
 )
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  query: postQuery,
+  order: '_updatedAt desc',
+  limit: 100,
+})
 
 async function fetchPost(slug: string) {
   'use cache'
@@ -25,7 +23,7 @@ async function fetchPost(slug: string) {
 
 export default async function PostPage({params}: PageProps<'/posts/[slug]'>) {
   const {slug} = await params
-  if (slug === '__placeholder__') notFound()
+  if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
   const post = await fetchPost(slug)
   if (!post) notFound()
 

--- a/apps/mvp/app/(website)/posts/[slug]/page.tsx
+++ b/apps/mvp/app/(website)/posts/[slug]/page.tsx
@@ -1,0 +1,46 @@
+import {defineQuery} from 'next-sanity'
+import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import Link from 'next/link'
+import {notFound} from 'next/navigation'
+
+import {client} from '@/app/sanity.client'
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "post" && defined(slug.current)',
+  params: {slug: 'slug.current'},
+  fallback: {slug: '__placeholder__'},
+  order: '_updatedAt desc',
+  limit: 100,
+})
+
+const postQuery = defineQuery(
+  `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
+)
+
+async function fetchPost(slug: string) {
+  'use cache'
+  return client.fetch(postQuery, {slug}, {perspective: 'published', stega: false})
+}
+
+export default async function PostPage({params}: PageProps<'/posts/[slug]'>) {
+  const {slug} = await params
+  if (slug === '__placeholder__') notFound()
+  const post = await fetchPost(slug)
+  if (!post) notFound()
+
+  return (
+    <article className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">{post.title}</h1>
+      {post.publishedAt ? (
+        <time className="mt-2 block text-sm text-gray-500" dateTime={post.publishedAt}>
+          {new Date(post.publishedAt).toDateString()}
+        </time>
+      ) : null}
+      <p className="mt-4 text-gray-600">Slug: {post.slug}</p>
+      <Link href="/" className="mt-8 inline-block text-blue-600 hover:underline">
+        Back to all posts
+      </Link>
+    </article>
+  )
+}

--- a/apps/mvp/package.json
+++ b/apps/mvp/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "start": "next start",
     "type-check": "next typegen && tsc --noEmit",
-    "typegen": "sanity schema extract --force && sanity typegen generate"
+    "typegen": "next typegen && sanity schema extract --force && sanity typegen generate"
   },
   "dependencies": {
     "@repo/sanity-config": "workspace:*",

--- a/apps/mvp/sanity.types.ts
+++ b/apps/mvp/sanity.types.ts
@@ -431,10 +431,20 @@ export type AllSanitySchemaTypes =
 // Query: *[_type == "post" && _id == $id][0].title
 export type PostTitleQueryResult = string | null
 
+// Source: app/(website)/posts/[slug]/page.tsx
+// Variable: postQuery
+// Query: *[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}
+export type PostQueryResult = {
+  title: string | null
+  slug: string | null
+  publishedAt: string | null
+} | null
+
 // Query TypeMap
 import '@sanity/client'
 declare module '@sanity/client' {
   interface SanityQueries {
     '*[_type == "post" && _id == $id][0].title': PostTitleQueryResult
+    '*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}': PostQueryResult
   }
 }

--- a/apps/static/app/posts/[slug]/page.tsx
+++ b/apps/static/app/posts/[slug]/page.tsx
@@ -1,0 +1,41 @@
+import {defineQuery} from 'next-sanity'
+import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import Link from 'next/link'
+import {notFound} from 'next/navigation'
+
+import {client} from '@/app/sanity.client'
+
+export const dynamic = 'force-static'
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "post" && defined(slug.current)',
+  params: {slug: 'slug.current'},
+  fallback: {slug: '__placeholder__'},
+})
+
+const postQuery = defineQuery(
+  `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
+)
+
+export default async function PostPage({params}: PageProps<'/posts/[slug]'>) {
+  const {slug} = await params
+  if (slug === '__placeholder__') notFound()
+  const post = await client.fetch(postQuery, {slug}, {perspective: 'published', stega: false})
+  if (!post) notFound()
+
+  return (
+    <article className="mx-auto max-w-2xl px-4 py-16">
+      <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">{post.title}</h1>
+      {post.publishedAt ? (
+        <time className="mt-2 block text-sm text-gray-500" dateTime={post.publishedAt}>
+          {new Date(post.publishedAt).toDateString()}
+        </time>
+      ) : null}
+      <p className="mt-4 text-gray-600">Slug: {post.slug}</p>
+      <Link href="/" className="mt-8 inline-block text-blue-600 hover:underline">
+        Back to all posts
+      </Link>
+    </article>
+  )
+}

--- a/apps/static/app/posts/[slug]/page.tsx
+++ b/apps/static/app/posts/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import {defineQuery} from 'next-sanity'
-import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from 'next-sanity/static-params'
 import Link from 'next/link'
 import {notFound} from 'next/navigation'
 
@@ -7,20 +7,15 @@ import {client} from '@/app/sanity.client'
 
 export const dynamic = 'force-static'
 
-export const {generateStaticParams} = defineGenerateStaticParams({
-  client,
-  filter: '_type == "post" && defined(slug.current)',
-  params: {slug: 'slug.current'},
-  fallback: {slug: '__placeholder__'},
-})
-
 const postQuery = defineQuery(
   `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
 )
 
+export const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
+
 export default async function PostPage({params}: PageProps<'/posts/[slug]'>) {
   const {slug} = await params
-  if (slug === '__placeholder__') notFound()
+  if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
   const post = await client.fetch(postQuery, {slug}, {perspective: 'published', stega: false})
   if (!post) notFound()
 

--- a/apps/static/package.json
+++ b/apps/static/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@repo/sanity-config": "workspace:*",
+    "@sanity/client": "catalog:",
     "@sanity/image-url": "catalog:",
     "@sanity/vision": "catalog:",
     "groqd": "catalog:",

--- a/apps/static/sanity.types.ts
+++ b/apps/static/sanity.types.ts
@@ -425,3 +425,20 @@ export type AllSanitySchemaTypes =
   | SanityAssetSourceData
   | SanityImageAsset
   | Geopoint
+
+// Source: app/posts/[slug]/page.tsx
+// Variable: postQuery
+// Query: *[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}
+export type PostQueryResult = {
+  title: string | null
+  slug: string | null
+  publishedAt: string | null
+} | null
+
+// Query TypeMap
+import '@sanity/client'
+declare module '@sanity/client' {
+  interface SanityQueries {
+    '*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}': PostQueryResult
+  }
+}

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -74,37 +74,53 @@ npx install-peerdeps --yarn next-sanity
 
 ## Static params for dynamic routes
 
-`next-sanity/static-params` builds a [`generateStaticParams`][generate-static-params] from a GROQ filter and one GROQ expression per route param. It is server and build-time only, so import it from route files and never from Client Components.
+`next-sanity/static-params` builds a [`generateStaticParams`][generate-static-params] from the page's own GROQ query. It is server and build-time only, so import it from route files and never from Client Components.
 
 ```tsx
 // app/posts/[slug]/page.tsx
-import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {defineQuery} from 'next-sanity'
+import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from 'next-sanity/static-params'
 import {notFound} from 'next/navigation'
 import {client} from '@/sanity/lib/client'
 
-export const {generateStaticParams} = defineGenerateStaticParams({
-  client,
-  filter: '_type == "post" && defined(slug.current)',
-  params: {slug: 'slug.current'},
-  fallback: {slug: '__placeholder__'},
-  order: '_updatedAt desc',
-  limit: 100,
-})
+const postQuery = defineQuery(
+  `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
+)
+
+export const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
 
 export default async function Page({params}: PageProps<'/posts/[slug]'>) {
   const {slug} = await params
-  if (slug === '__placeholder__') notFound()
-  // fetch and render the post
+  if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
+  const post = await client.fetch(postQuery, {slug})
+  // render the post
 }
 ```
 
-What it does for you:
+When the route module loads, `groq-js` parses the query and reads the root `*[...]` filter. Each `<expression> == $param` conjunct names a route param and the expression that produces it. The other conjuncts stay as constraints. The `[0]`, slices, `order()`, and projection after the filter are dropped. The query above becomes `*[_type == "post" && defined(slug.current)]{"slug": slug.current}`. A syntax error, a `$param` that is not bound with `==`, or a query without bindings fails `next build` with the offending expression before any network request.
 
-- Assembles `*[<filter>] | order(<order>)[0...<limit>]{"slug": slug.current}` and parses the filter, every param expression, and the assembled query with `groq-js` when the module loads. A syntax error fails `next build` immediately and names the expression and its position.
+At build time the returned `generateStaticParams` does the following:
+
 - Fetches with `perspective: 'published'`, `useCdn: true`, and stega and source maps off. Cookies are not available during `next build`, and param values are never rendered.
-- Drops documents whose param value is `null`, empty, or of the wrong kind, removes duplicates, and returns `[fallback]` when nothing remains. Cache Components fails the build when `generateStaticParams` returns `[]`, so the fallback is required. Handle it in the page with `notFound()`.
-- Types the result from `fallback`. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment, for example `params: {path: 'string::split(slug.current, "/")'}` with `fallback: {path: ['__placeholder__']}`.
-- Forwards the parent segment's params to GROQ, so `app/[category]/[slug]/page.tsx` can use `filter: '_type == "post" && category->slug.current == $category'`.
+- Drops documents whose param value is `null`, empty, or of the wrong kind, and removes duplicates.
+- Returns `[{slug: STATIC_PARAMS_PLACEHOLDER}]` when nothing remains. Cache Components fails the build when `generateStaticParams` returns `[]`, and the [Next.js error page][empty-generate-static-params] names this placeholder as the fallback. It also warns that a placeholder only validates the `notFound()` path, so the helper uses it only when the query returns nothing.
+- Turns a binding into a constraint when the parent segment already provides the param. For `app/[category]/[slug]/page.tsx` with `*[_type == "post" && category->slug.current == $category && slug.current == $slug][0]`, Next.js calls `generateStaticParams({params: {category}})` and the result is `{slug}[]`.
+
+Pass `order` and `limit` to prerender only the most recent documents, for example `order: '_updatedAt desc', limit: 100`.
+
+A catch-all segment needs a `fallback`, because the query cannot tell `[slug]` from `[...slug]`. A `string[]` value declares the catch-all and types the result:
+
+```ts
+const docQuery = defineQuery(`*[_type == "doc" && string::split(slug.current, "/") == $path][0]`)
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  query: docQuery,
+  fallback: {path: [STATIC_PARAMS_PLACEHOLDER]},
+})
+```
+
+The result type defaults to `Record<string, string>[]`. Next.js checks the returned params against the route at build time, so a type annotation is optional. Pass the shape as a generic when you want it, `defineGenerateStaticParams<{slug: string}>({client, query})`.
 
 A root param that needs a constant value, such as `app/[perspective]/layout.tsx`, does not need the helper. Return the constant directly:
 
@@ -146,6 +162,7 @@ The returned `query` string is the assembled GROQ. Pass it to `sanityFetch` from
 MIT-licensed. See [LICENSE][LICENSE].
 
 [embedded-studio]: https://www.sanity.io/docs/nextjs/embedding-sanity-studio-in-nextjs
+[empty-generate-static-params]: https://nextjs.org/docs/messages/empty-generate-static-params
 [generate-static-params]: https://nextjs.org/docs/app/api-reference/functions/generate-static-params
 [LICENSE]: LICENSE
 [migrate-v1-to-v4]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v1-to-v4.md

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -102,8 +102,8 @@ What it does for you:
 
 - Assembles `*[<filter>] | order(<order>)[0...<limit>]{"slug": slug.current}` and parses the filter, every param expression, and the assembled query with `groq-js` when the module loads. A syntax error fails `next build` immediately and names the expression and its position.
 - Fetches with `perspective: 'published'`, `useCdn: true`, and stega and source maps off. Cookies are not available during `next build`, and param values are never rendered.
-- Drops documents whose param value is `null` or of the wrong kind, removes duplicates, and returns `[fallback]` when nothing remains. Cache Components fails the build when `generateStaticParams` returns `[]`, so the fallback is required. Handle it in the page with `notFound()`.
-- Types the result from `fallback`. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` or `[[...slug]]` segment, for example `params: {path: 'string::split(slug.current, "/")'}` with `fallback: {path: ['__placeholder__']}`.
+- Drops documents whose param value is `null`, empty, or of the wrong kind, removes duplicates, and returns `[fallback]` when nothing remains. Cache Components fails the build when `generateStaticParams` returns `[]`, so the fallback is required. Handle it in the page with `notFound()`.
+- Types the result from `fallback`. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` segment, for example `params: {path: 'string::split(slug.current, "/")'}` with `fallback: {path: ['__placeholder__']}`.
 - Forwards the parent segment's params to GROQ, so `app/[category]/[slug]/page.tsx` can use `filter: '_type == "post" && category->slug.current == $category'`.
 
 A root param that needs a constant value, such as `app/[perspective]/layout.tsx`, does not need the helper. Return the constant directly:

--- a/packages/next-sanity/README.md
+++ b/packages/next-sanity/README.md
@@ -18,6 +18,7 @@ The all-in-one [Sanity][sanity] toolkit for production-grade content-editable Ne
 - [Manual installation](#manual-installation)
   - [Install `next-sanity`](#install-next-sanity)
   - [Optional: peer dependencies for embedded Sanity Studio](#optional-peer-dependencies-for-embedded-sanity-studio)
+- [Static params for dynamic routes](#static-params-for-dynamic-routes)
 - [Migration guides](#migration-guides)
 - [License](#license)
 
@@ -71,6 +72,60 @@ When using `npm` newer than `v7`, or `pnpm` newer than `v8`, you should end up w
 npx install-peerdeps --yarn next-sanity
 ```
 
+## Static params for dynamic routes
+
+`next-sanity/static-params` builds a [`generateStaticParams`][generate-static-params] from a GROQ filter and one GROQ expression per route param. It is server and build-time only, so import it from route files and never from Client Components.
+
+```tsx
+// app/posts/[slug]/page.tsx
+import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {notFound} from 'next/navigation'
+import {client} from '@/sanity/lib/client'
+
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "post" && defined(slug.current)',
+  params: {slug: 'slug.current'},
+  fallback: {slug: '__placeholder__'},
+  order: '_updatedAt desc',
+  limit: 100,
+})
+
+export default async function Page({params}: PageProps<'/posts/[slug]'>) {
+  const {slug} = await params
+  if (slug === '__placeholder__') notFound()
+  // fetch and render the post
+}
+```
+
+What it does for you:
+
+- Assembles `*[<filter>] | order(<order>)[0...<limit>]{"slug": slug.current}` and parses the filter, every param expression, and the assembled query with `groq-js` when the module loads. A syntax error fails `next build` immediately and names the expression and its position.
+- Fetches with `perspective: 'published'`, `useCdn: true`, and stega and source maps off. Cookies are not available during `next build`, and param values are never rendered.
+- Drops documents whose param value is `null` or of the wrong kind, removes duplicates, and returns `[fallback]` when nothing remains. Cache Components fails the build when `generateStaticParams` returns `[]`, so the fallback is required. Handle it in the page with `notFound()`.
+- Types the result from `fallback`. A `string` value declares a `[slug]` segment and a `string[]` value declares a `[...slug]` or `[[...slug]]` segment, for example `params: {path: 'string::split(slug.current, "/")'}` with `fallback: {path: ['__placeholder__']}`.
+- Forwards the parent segment's params to GROQ, so `app/[category]/[slug]/page.tsx` can use `filter: '_type == "post" && category->slug.current == $category'`.
+
+A root param that needs a constant value, such as `app/[perspective]/layout.tsx`, does not need the helper. Return the constant directly:
+
+```ts
+export function generateStaticParams() {
+  return [{perspective: 'published'}]
+}
+```
+
+When you write the query yourself, `ensureStaticParams` applies the same fallback rule:
+
+```ts
+import {ensureStaticParams} from 'next-sanity/static-params'
+
+export async function generateStaticParams() {
+  return ensureStaticParams(await getArticleStaticParams(), {article: '_', section: '_'})
+}
+```
+
+The returned `query` string is the assembled GROQ. Pass it to `sanityFetch` from `next-sanity/live` with `perspective: 'published'` and `stega: false` when you want the fetch to carry cache tags.
+
 ## Migration guides
 
 - [From `v12` to `v13`][migrate-v12-to-v13]
@@ -91,6 +146,7 @@ npx install-peerdeps --yarn next-sanity
 MIT-licensed. See [LICENSE][LICENSE].
 
 [embedded-studio]: https://www.sanity.io/docs/nextjs/embedding-sanity-studio-in-nextjs
+[generate-static-params]: https://nextjs.org/docs/app/api-reference/functions/generate-static-params
 [LICENSE]: LICENSE
 [migrate-v1-to-v4]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v1-to-v4.md
 [migrate-v4-to-v5-app]: https://github.com/sanity-io/next-sanity/blob/main/packages/next-sanity/MIGRATE-v4-to-v5-app-router.md

--- a/packages/next-sanity/package.json
+++ b/packages/next-sanity/package.json
@@ -49,6 +49,7 @@
     "./live/cache-life": "./src/live/cache-life.ts",
     "./live/client-components": "./src/live/client-components/index.ts",
     "./live/server-actions": "./src/live/server-actions/index.ts",
+    "./static-params": "./src/static-params/index.ts",
     "./studio": "./src/studio/index.ts",
     "./studio/client-component": "./src/studio/client-component/index.ts",
     "./visual-editing": "./src/visual-editing/index.ts",
@@ -71,6 +72,7 @@
       "./live/cache-life": "./dist/live/cache-life.js",
       "./live/client-components": "./dist/live/client-components/index.js",
       "./live/server-actions": "./dist/live/server-actions/index.js",
+      "./static-params": "./dist/static-params/index.js",
       "./studio": "./dist/studio/index.js",
       "./studio/client-component": "./dist/studio/client-component/index.js",
       "./visual-editing": "./dist/visual-editing/index.js",
@@ -97,6 +99,7 @@
     "@sanity/visual-editing": "^6.0.4",
     "@sanity/webhook": "^4.0.4",
     "groq": "^6.12.0",
+    "groq-js": "^2.0.0",
     "history": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/next-sanity/src/__tests__/exports.spec.ts
+++ b/packages/next-sanity/src/__tests__/exports.spec.ts
@@ -55,6 +55,7 @@ test(`exports snapshot for the ${JSON.stringify(env)} condition`, {timeout: 15_0
       ./static-params:
         defineGenerateStaticParams: function
         ensureStaticParams: function
+        STATIC_PARAMS_PLACEHOLDER: string
       ./studio:
         metadata: object
         NextStudio: function

--- a/packages/next-sanity/src/__tests__/exports.spec.ts
+++ b/packages/next-sanity/src/__tests__/exports.spec.ts
@@ -52,6 +52,9 @@ test(`exports snapshot for the ${JSON.stringify(env)} condition`, {timeout: 15_0
         SanityLive: function
       ./live/server-actions:
         revalidateSyncTagsAction: function
+      ./static-params:
+        defineGenerateStaticParams: function
+        ensureStaticParams: function
       ./studio:
         metadata: object
         NextStudio: function

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -1,5 +1,5 @@
 import type {QueryParams, SanityClient} from '@sanity/client'
-import {GroqSyntaxError, parse} from 'groq-js'
+import {GroqSyntaxError, parse, unparse} from 'groq-js'
 
 /**
  * A single route param value. `string` for `[slug]`, `string[]` for `[...slug]`.
@@ -12,6 +12,18 @@ export type StaticParamValue = string | string[]
  * @public
  */
 export type StaticParams = Record<string, StaticParamValue>
+
+/**
+ * The value `generateStaticParams` returns for every param when the query yields no
+ * documents. Cache Components fails `next build` on an empty result, so one path must
+ * always prerender. Compare against it in the page and call `notFound()`.
+ *
+ * Next.js documents this placeholder at
+ * https://nextjs.org/docs/messages/empty-generate-static-params and warns that it only
+ * validates the `notFound()` path, so prefer a dataset that returns real documents.
+ * @public
+ */
+export const STATIC_PARAMS_PLACEHOLDER = '__placeholder__'
 
 /**
  * The argument Next.js passes to `generateStaticParams` in a nested dynamic segment.
@@ -34,31 +46,29 @@ export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
    */
   client: SanityClient
   /**
-   * GROQ filter placed inside `*[...]`. Parent segment params are available as GROQ
-   * params, so `app/[category]/[slug]/page.tsx` can write
-   * `'_type == "post" && category->slug.current == $category'`.
-   */
-  filter: string
-  /**
-   * One GROQ expression per route param, evaluated against each matching document.
-   * The keys must match the keys of `fallback`; they become the param names.
+   * The page's own GROQ query. Every `<expression> == $param` conjunct in the root
+   * `*[...]` filter names a route param and the expression that produces it. The other
+   * conjuncts stay as constraints. Everything after the filter is dropped.
    * @example
    * ```ts
-   * {slug: 'slug.current'}
-   * {category: 'category->slug.current', slug: 'slug.current'}
-   * {path: 'string::split(slug.current, "/")'}
+   * `*[_type == "post" && slug.current == $slug][0]{title, body}`
+   * `*[_type == "post" && category->slug.current == $category && slug.current == $slug][0]`
+   * `*[_type == "doc" && string::split(slug.current, "/") == $path][0]`
    * ```
    */
-  params: {[Key in keyof NoInfer<Shape>]: string}
+  query: string
   /**
-   * Returned as the only entry when the query yields no usable params, because
-   * Cache Components fails `next build` when `generateStaticParams` returns `[]`.
-   * Its shape also types the result. A `string` value declares a `[slug]` segment,
-   * a `string[]` value declares a `[...slug]` segment. Each value must be a non-empty
-   * string or a non-empty array of non-empty strings, since Next.js cannot route an
-   * empty segment. Handle the placeholder in the page with `notFound()`.
+   * Overrides the placeholder entry for some or all params. Required for a catch-all
+   * segment, because the query cannot tell `[slug]` from `[...slug]`. A `string[]` value
+   * declares `[...slug]` and drops rows that are not arrays of non-empty strings. Each
+   * value must be a non-empty string or a non-empty array of non-empty strings, since
+   * Next.js cannot route an empty segment.
+   * @example
+   * ```ts
+   * {path: [STATIC_PARAMS_PLACEHOLDER]}
+   * ```
    */
-  fallback: Shape
+  fallback?: Partial<Shape>
   /**
    * Optional `order()` clause, for example `'_updatedAt desc'`.
    */
@@ -75,14 +85,16 @@ export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
  */
 export interface DefinedGenerateStaticParams<Shape extends StaticParams> {
   /**
-   * The assembled and syntax-checked GROQ query, for example
-   * `*[_type == "post"] | order(_updatedAt desc) [0...100]{"slug": slug.current}`.
+   * The GROQ query that runs when no parent params are given, for example
+   * `*[_type == "post" && defined(slug.current)] | order(_updatedAt desc)[0...100]{"slug": slug.current}`.
+   * groq-js prints the kept conjuncts, so `defined(x)` appears as `global::defined(x)`.
    * Useful for tests, or for fetching through `sanityFetch` when you want its cache tags.
    */
   query: string
   /**
    * Export this from the route file. Accepts the `{params}` argument Next.js passes to
-   * nested segments and forwards those params to GROQ as `$name` variables.
+   * nested segments. A param the parent already provides becomes a GROQ constraint and
+   * is left out of the result. The remaining params are generated.
    */
   generateStaticParams: (args?: GenerateStaticParamsArgs) => Promise<Shape[]>
 }
@@ -110,68 +122,78 @@ export function ensureStaticParams<T extends Record<string, null | string | stri
 }
 
 /**
- * Builds a `generateStaticParams` for a dynamic route from a GROQ filter and one GROQ
- * expression per route param.
+ * Builds a `generateStaticParams` for a dynamic route from the page's own GROQ query.
  *
- * This function assembles the query and parses it with `groq-js`. It runs when the route
- * module loads, so a GROQ typo fails `next build` with the expression and its position
- * before any network request. The returned `generateStaticParams` fetches from the
- * published perspective, drops rows whose param values are `null`, empty, or of the wrong
- * kind, removes duplicates, and returns `[fallback]` for an empty result via
+ * The query is parsed with `groq-js` when the route module loads. Each
+ * `<expression> == $param` conjunct in the root `*[...]` filter becomes a route param,
+ * the other conjuncts stay as constraints, and the `[0]`, slices, ordering, and
+ * projection after the filter are dropped. `*[_type == "post" && slug.current == $slug][0]{title}`
+ * becomes `*[_type == "post" && defined(slug.current)]{"slug": slug.current}`. A syntax
+ * error, a `$param` that is not bound with `==`, or a query without bindings fails
+ * `next build` with the offending expression before any network request.
+ *
+ * The returned `generateStaticParams` fetches from the published perspective, drops rows
+ * whose param values are `null`, empty, or of the wrong kind, removes duplicates, and
+ * returns one {@link STATIC_PARAMS_PLACEHOLDER} entry when nothing remains, via
  * {@link ensureStaticParams}.
  *
  * @example
  * ```tsx
  * // app/posts/[slug]/page.tsx
- * import {defineGenerateStaticParams} from 'next-sanity/static-params'
+ * import {defineQuery} from 'next-sanity'
+ * import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from 'next-sanity/static-params'
  * import {notFound} from 'next/navigation'
  * import {client} from '@/sanity/client'
  *
- * export const {generateStaticParams} = defineGenerateStaticParams({
- *   client,
- *   filter: '_type == "post" && defined(slug.current)',
- *   params: {slug: 'slug.current'},
- *   fallback: {slug: '__placeholder__'},
- *   order: '_updatedAt desc',
- *   limit: 100,
- * })
+ * const postQuery = defineQuery(
+ *   `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
+ * )
+ * export const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
  *
  * export default async function Page({params}: PageProps<'/posts/[slug]'>) {
  *   const {slug} = await params
- *   if (slug === '__placeholder__') notFound()
+ *   if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
+ *   const post = await client.fetch(postQuery, {slug})
  *   // ...
  * }
  * ```
  *
  * @example
  * ```tsx
- * // app/[category]/[slug]/page.tsx, the parent segment's params arrive as GROQ params
- * export const {generateStaticParams} = defineGenerateStaticParams({
- *   client,
- *   filter: '_type == "post" && category->slug.current == $category',
- *   params: {slug: 'slug.current'},
- *   fallback: {slug: '__placeholder__'},
- * })
+ * // app/[category]/[slug]/page.tsx receives {params: {category}} from the parent segment,
+ * // so `$category` becomes a constraint and only `slug` is generated
+ * const postQuery = defineQuery(
+ *   `*[_type == "post" && category->slug.current == $category && slug.current == $slug][0]{title}`,
+ * )
+ * export const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
  * ```
  *
  * @example
  * ```tsx
- * // app/docs/[...path]/page.tsx, a `string[]` fallback declares a catch-all segment
+ * // app/docs/[...path]/page.tsx, a `string[]` fallback declares the catch-all segment
+ * const docQuery = defineQuery(`*[_type == "doc" && string::split(slug.current, "/") == $path][0]`)
  * export const {generateStaticParams} = defineGenerateStaticParams({
  *   client,
- *   filter: '_type == "doc" && defined(slug.current)',
- *   params: {path: 'string::split(slug.current, "/")'},
- *   fallback: {path: ['__placeholder__']},
+ *   query: docQuery,
+ *   fallback: {path: [STATIC_PARAMS_PLACEHOLDER]},
  * })
  * ```
  * @public
  */
-export function defineGenerateStaticParams<Shape extends StaticParams>(
+export function defineGenerateStaticParams<Shape extends StaticParams = Record<string, string>>(
   options: DefineGenerateStaticParamsOptions<Shape>,
 ): DefinedGenerateStaticParams<Shape> {
-  const {client, filter, params, fallback, order, limit} = options
-  const query = assembleQuery({filter, params, order, limit})
-  assertFallback(fallback)
+  const {client, query: pageQuery, order, limit} = options
+  const fallback: Partial<StaticParams> = options.fallback ?? {}
+  const plan = inferStaticParamsQuery(pageQuery)
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    throw new TypeError(
+      `defineGenerateStaticParams: \`limit\` must be a positive integer, got ${String(limit)}`,
+    )
+  }
+  assertFallback(fallback, plan)
+  const query = assembleQuery(plan, {}, order, limit)
+  parseGroq(query, 'query')
 
   const staticClient = client.withConfig({
     perspective: 'published',
@@ -183,48 +205,219 @@ export function defineGenerateStaticParams<Shape extends StaticParams>(
   return {
     query,
     async generateStaticParams(args) {
-      const queryParams: QueryParams = args?.params ?? {}
-      const rows = await staticClient.fetch<unknown>(query, queryParams)
-      return ensureStaticParams(pickStaticParams(rows, fallback), fallback)
+      const parentParams = args?.params ?? {}
+      const sample: StaticParams = {}
+      const queryParams: QueryParams = {}
+      for (const conjunct of plan) {
+        if (conjunct.kind !== 'binding') continue
+        if (Object.hasOwn(parentParams, conjunct.param)) {
+          queryParams[conjunct.param] = parentParams[conjunct.param]
+        } else {
+          sample[conjunct.param] = fallback[conjunct.param] ?? STATIC_PARAMS_PLACEHOLDER
+        }
+      }
+      if (Object.keys(sample).length === 0) {
+        throw new Error(
+          'defineGenerateStaticParams: the parent params already bind every $param, nothing is left to generate',
+        )
+      }
+      const rows = await staticClient.fetch<unknown>(
+        assembleQuery(plan, parentParams, order, limit),
+        queryParams,
+      )
+      // oxlint-disable-next-line no-unsafe-type-assertion
+      return ensureStaticParams(pickStaticParams(rows, sample), sample) as Shape[]
     },
   }
 }
 
-interface QueryPieces {
-  filter: string
-  params: Record<string, string>
-  order?: string | undefined
-  limit?: number | undefined
+/**
+ * One top-level `&&` conjunct of the page query's root filter, in source order.
+ * A binding is `<expr> == $param`. Everything else is a constraint.
+ */
+type Conjunct = {kind: 'constraint'; groq: string} | {kind: 'binding'; param: string; expr: string}
+
+/**
+ * groq-js 2.0.0 ships no declarations for its AST nodes, so these name the few shapes
+ * the walk inspects. Every other node only matters as an opaque subtree.
+ */
+interface GroqNode {
+  type: string
+  base?: GroqNode
 }
 
-function assembleQuery({filter, params, order, limit}: QueryPieces): string {
-  assertGroq(filter, 'filter')
-  const keys = Object.keys(params)
-  if (keys.length === 0) {
-    throw new TypeError(
-      'defineGenerateStaticParams: `params` must declare at least one route param',
-    )
-  }
-  for (const key of keys) {
-    assertGroq(params[key], `params.${key}`)
-  }
-  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
-    throw new TypeError(
-      `defineGenerateStaticParams: \`limit\` must be a positive integer, got ${String(limit)}`,
-    )
-  }
+interface FilterNode extends GroqNode {
+  type: 'Filter'
+  base: GroqNode
+  expr: GroqNode
+}
 
-  const projection = keys.map((key) => `${JSON.stringify(key)}: ${params[key]}`).join(', ')
+interface AndNode extends GroqNode {
+  type: 'And'
+  left: GroqNode
+  right: GroqNode
+}
+
+interface GroupNode extends GroqNode {
+  type: 'Group'
+  base: GroqNode
+}
+
+interface OpCallNode extends GroqNode {
+  type: 'OpCall'
+  op: string
+  left: GroqNode
+  right: GroqNode
+}
+
+interface ParameterNode extends GroqNode {
+  type: 'Parameter'
+  name: string
+}
+
+function inferStaticParamsQuery(query: string): Conjunct[] {
+  const root: GroqNode = parseGroq(query, 'query')
+  const plan: Conjunct[] = []
+  const boundBy = new Map<string, string>()
+  for (const node of rootFilterExprs(root).flatMap((expr) => conjuncts(expr))) {
+    const binding = asBinding(node)
+    if (!binding) {
+      if (containsParameter(node)) {
+        throw new Error(
+          `defineGenerateStaticParams: every $param in the root filter must be bound as \`<expression> == $param\` in a top-level &&, found ${unparse(node)}`,
+        )
+      }
+      plan.push({kind: 'constraint', groq: unparse(node)})
+      continue
+    }
+    const previous = boundBy.get(binding.param)
+    if (previous !== undefined) {
+      throw new Error(
+        `defineGenerateStaticParams: \`$${binding.param}\` is bound twice, by ${previous} and ${binding.expr}`,
+      )
+    }
+    boundBy.set(binding.param, binding.expr)
+    plan.push({kind: 'binding', ...binding})
+  }
+  if (boundBy.size === 0) {
+    throw new Error(
+      'defineGenerateStaticParams: the query binds no $param, add a conjunct such as `slug.current == $slug`',
+    )
+  }
+  return plan
+}
+
+/**
+ * Walks down the `base` chain from the query root to the filter that sits on `*`, and
+ * returns the `expr` of every filter in that chain, outermost last. `*[A][B]` reads as
+ * `*[A && B]`. A filter that sits on anything else, such as `*[A]{...}[B]`, is rejected
+ * because `B` would refer to the projected shape.
+ */
+function rootFilterExprs(root: GroqNode): GroqNode[] {
+  let node: GroqNode | undefined = root
+  while (node && !isFilter(node)) node = node.base
+  const exprs: GroqNode[] = []
+  while (node && isFilter(node)) {
+    exprs.unshift(node.expr)
+    node = node.base
+  }
+  if (node?.type === 'Everything') return exprs
+  throw new Error('defineGenerateStaticParams: the query must start with `*[...]`')
+}
+
+function conjuncts(expr: GroqNode, out: GroqNode[] = []): GroqNode[] {
+  if (isGroup(expr) && (isAnd(expr.base) || isOpCall(expr.base))) return conjuncts(expr.base, out)
+  if (isAnd(expr)) {
+    conjuncts(expr.left, out)
+    conjuncts(expr.right, out)
+    return out
+  }
+  out.push(expr)
+  return out
+}
+
+function asBinding(node: GroqNode): {param: string; expr: string} | undefined {
+  if (!isOpCall(node) || node.op !== '==') return undefined
+  if (isParameter(node.left) && isParameter(node.right)) {
+    throw new Error(
+      `defineGenerateStaticParams: \`${unparse(node)}\` binds a param to another param`,
+    )
+  }
+  const [param, expr] = isParameter(node.left)
+    ? [node.left, node.right]
+    : isParameter(node.right)
+      ? [node.right, node.left]
+      : []
+  if (!param || !expr || containsParameter(expr)) return undefined
+  return {param: param.name, expr: unparse(expr)}
+}
+
+function containsParameter(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(containsParameter)
+  if (!isRecord(node)) return false
+  if (node['type'] === 'Parameter') return true
+  return Object.values(node).some(containsParameter)
+}
+
+function isFilter(node: GroqNode): node is FilterNode {
+  return node.type === 'Filter'
+}
+
+function isAnd(node: GroqNode): node is AndNode {
+  return node.type === 'And'
+}
+
+function isGroup(node: GroqNode): node is GroupNode {
+  return node.type === 'Group'
+}
+
+function isOpCall(node: GroqNode): node is OpCallNode {
+  return node.type === 'OpCall'
+}
+
+function isParameter(node: GroqNode): node is ParameterNode {
+  return node.type === 'Parameter'
+}
+
+function assembleQuery(
+  plan: Conjunct[],
+  parentParams: StaticParams,
+  order: string | undefined,
+  limit: number | undefined,
+): string {
+  const filter: string[] = []
+  const projection: string[] = []
+  for (const conjunct of plan) {
+    switch (conjunct.kind) {
+      case 'constraint':
+        filter.push(conjunct.groq)
+        break
+      case 'binding':
+        if (Object.hasOwn(parentParams, conjunct.param)) {
+          filter.push(`${conjunct.expr} == $${conjunct.param}`)
+        } else {
+          filter.push(`defined(${conjunct.expr})`)
+          projection.push(`${JSON.stringify(conjunct.param)}: ${conjunct.expr}`)
+        }
+        break
+      default:
+        conjunct satisfies never
+    }
+  }
   const pipe = order === undefined ? '' : ` | order(${order})`
   const slice = limit === undefined ? '' : `[0...${limit}]`
-  const query = `*[${filter}]${pipe}${slice}{${projection}}`
-  assertGroq(query, 'query')
-  return query
+  return `*[${filter.join(' && ')}]${pipe}${slice}{${projection.join(', ')}}`
 }
 
-function assertFallback(fallback: StaticParams): void {
-  for (const key of Object.keys(fallback)) {
-    if (!isRoutableValue(fallback[key], fallback[key])) {
+function assertFallback(fallback: Partial<StaticParams>, plan: Conjunct[]): void {
+  const bound = plan.flatMap((conjunct) => (conjunct.kind === 'binding' ? [conjunct.param] : []))
+  for (const [key, value] of Object.entries(fallback)) {
+    if (!bound.includes(key)) {
+      throw new TypeError(
+        `defineGenerateStaticParams: \`fallback.${key}\` does not match a $param, bound params: ${bound.join(', ')}`,
+      )
+    }
+    if (!isRoutableValue(value, value)) {
       throw new TypeError(
         `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
       )
@@ -232,9 +425,10 @@ function assertFallback(fallback: StaticParams): void {
   }
 }
 
-function assertGroq(source: string, where: string): void {
+function parseGroq(source: string, where: string): GroqNode {
   try {
-    parse(source)
+    const root: GroqNode = parse(source)
+    return root
   } catch (error) {
     const position = error instanceof GroqSyntaxError ? ` at position ${error.position}` : ''
     const message = error instanceof Error ? error.message : String(error)
@@ -245,18 +439,18 @@ function assertGroq(source: string, where: string): void {
   }
 }
 
-function pickStaticParams<Shape extends StaticParams>(rows: unknown, fallback: Shape): Shape[] {
+function pickStaticParams(rows: unknown, sample: StaticParams): StaticParams[] {
   if (!Array.isArray(rows)) {
     throw new TypeError(
       `defineGenerateStaticParams: expected the query to return an array, got ${typeof rows}`,
     )
   }
   const seen = new Set<string>()
-  const result: Shape[] = []
+  const result: StaticParams[] = []
   for (const row of rows) {
     if (!isRecord(row)) continue
-    const picked = pickKeys(row, fallback)
-    if (!hasShape(picked, fallback)) continue
+    const picked = pickKeys(row, sample)
+    if (!hasShape(picked, sample)) continue
     const identity = JSON.stringify(picked)
     if (seen.has(identity)) continue
     seen.add(identity)
@@ -273,10 +467,7 @@ function pickKeys(row: Record<string, unknown>, sample: StaticParams): Record<st
   return picked
 }
 
-function hasShape<Shape extends StaticParams>(
-  value: Record<string, unknown>,
-  sample: Shape,
-): value is Shape {
+function hasShape(value: Record<string, unknown>, sample: StaticParams): value is StaticParams {
   return Object.keys(sample).every((key) => isRoutableValue(value[key], sample[key]))
 }
 
@@ -292,7 +483,7 @@ function isNonEmptyString(value: unknown): value is string {
  * Next.js only checks that a `[...slug]` value is an array and a `[slug]` value is a
  * string, so `''` and `[]` pass its validation and would prerender an empty segment.
  */
-function isRoutableValue(value: unknown, sample: StaticParamValue): value is StaticParamValue {
+function isRoutableValue(value: unknown, sample: unknown): value is StaticParamValue {
   if (Array.isArray(sample)) {
     return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyString)
   }

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -28,7 +28,7 @@ export interface GenerateStaticParamsArgs {
  */
 export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
   /**
-   * The client used to fetch documents at build time. It is reconfigured with
+   * The client that fetches documents at build time. The helper reconfigures it with
    * `perspective: 'published'`, `useCdn: true`, and stega and source maps off, because
    * route params are never rendered and cookies are unavailable during `next build`.
    */
@@ -65,7 +65,7 @@ export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
   order?: string
   /**
    * Optional cap on the number of documents, applied as `[0...limit]` after `order`.
-   * Prerendering only the most relevant pages keeps `next build` fast; the rest render on demand.
+   * Prerender only the first `limit` documents in `order` and let the rest render on demand.
    */
   limit?: number
 }
@@ -113,12 +113,12 @@ export function ensureStaticParams<T extends Record<string, null | string | stri
  * Builds a `generateStaticParams` for a dynamic route from a GROQ filter and one GROQ
  * expression per route param.
  *
- * The query is assembled and parsed with `groq-js` when this function runs, which is at
- * module evaluation of the route file, so `next build` fails fast with the offending
- * expression and its position instead of a network error later in the build.
- * Documents are fetched from the published perspective. Rows whose param values are
- * `null`, empty, or of the wrong kind are dropped, duplicates are removed, and an empty
- * result becomes `[fallback]` via {@link ensureStaticParams}.
+ * This function assembles the query and parses it with `groq-js`. It runs when the route
+ * module loads, so a GROQ typo fails `next build` with the expression and its position
+ * before any network request. The returned `generateStaticParams` fetches from the
+ * published perspective, drops rows whose param values are `null`, empty, or of the wrong
+ * kind, removes duplicates, and returns `[fallback]` for an empty result via
+ * {@link ensureStaticParams}.
  *
  * @example
  * ```tsx

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -2,7 +2,7 @@ import type {QueryParams, SanityClient} from '@sanity/client'
 import {GroqSyntaxError, parse} from 'groq-js'
 
 /**
- * A single route param value. `string` for `[slug]`, `string[]` for `[...slug]` and `[[...slug]]`.
+ * A single route param value. `string` for `[slug]`, `string[]` for `[...slug]`.
  * @public
  */
 export type StaticParamValue = string | string[]
@@ -54,8 +54,9 @@ export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
    * Returned as the only entry when the query yields no usable params, because
    * Cache Components fails `next build` when `generateStaticParams` returns `[]`.
    * Its shape also types the result. A `string` value declares a `[slug]` segment,
-   * a `string[]` value declares a `[...slug]` or `[[...slug]]` segment.
-   * Handle the placeholder in the page with `notFound()`.
+   * a `string[]` value declares a `[...slug]` segment. Each value must be a non-empty
+   * string or a non-empty array of non-empty strings, since Next.js cannot route an
+   * empty segment. Handle the placeholder in the page with `notFound()`.
    */
   fallback: Shape
   /**
@@ -116,8 +117,8 @@ export function ensureStaticParams<T extends Record<string, null | string | stri
  * module evaluation of the route file, so `next build` fails fast with the offending
  * expression and its position instead of a network error later in the build.
  * Documents are fetched from the published perspective. Rows whose param values are
- * `null` or of the wrong kind are dropped, duplicates are removed, and an empty result
- * becomes `[fallback]` via {@link ensureStaticParams}.
+ * `null`, empty, or of the wrong kind are dropped, duplicates are removed, and an empty
+ * result becomes `[fallback]` via {@link ensureStaticParams}.
  *
  * @example
  * ```tsx
@@ -170,6 +171,7 @@ export function defineGenerateStaticParams<Shape extends StaticParams>(
 ): DefinedGenerateStaticParams<Shape> {
   const {client, filter, params, fallback, order, limit} = options
   const query = assembleQuery({filter, params, order, limit})
+  assertFallback(fallback)
 
   const staticClient = client.withConfig({
     perspective: 'published',
@@ -220,6 +222,16 @@ function assembleQuery({filter, params, order, limit}: QueryPieces): string {
   return query
 }
 
+function assertFallback(fallback: StaticParams): void {
+  for (const key of Object.keys(fallback)) {
+    if (!isRoutableValue(fallback[key], fallback[key])) {
+      throw new TypeError(
+        `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
+      )
+    }
+  }
+}
+
 function assertGroq(source: string, where: string): void {
   try {
     parse(source)
@@ -262,7 +274,7 @@ function pickRow<Shape extends StaticParams>(
   const picked: StaticParams = {}
   for (const key of keys) {
     const value = row[key]
-    if (!matchesKind(value, fallback[key])) return undefined
+    if (!isRoutableValue(value, fallback[key])) return undefined
     picked[key] = value
   }
   // Every key of `fallback` was checked against its declared kind, which is what `Shape` promises.
@@ -274,9 +286,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
 
-function matchesKind(value: unknown, sample: StaticParamValue): value is StaticParamValue {
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== ''
+}
+
+/**
+ * `sample` decides the kind, `value` is what has to fit it. Empty strings and
+ * empty arrays never fit, since Next.js cannot route to an empty segment and a
+ * `[...slug]` route given `[]` would resolve to the parent path.
+ */
+function isRoutableValue(value: unknown, sample: StaticParamValue): value is StaticParamValue {
   if (Array.isArray(sample)) {
-    return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyString)
   }
-  return typeof value === 'string'
+  return isNonEmptyString(value)
 }

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -1,0 +1,280 @@
+import type {QueryParams, SanityClient} from '@sanity/client'
+import {GroqSyntaxError, parse} from 'groq-js'
+
+/**
+ * A single route param value. `string` for `[slug]`, `string[]` for `[...slug]` and `[[...slug]]`.
+ * @public
+ */
+export type StaticParamValue = string | string[]
+
+/**
+ * The params object Next.js expects each `generateStaticParams` entry to be.
+ * @public
+ */
+export type StaticParams = Record<string, StaticParamValue>
+
+/**
+ * The argument Next.js passes to `generateStaticParams` in a nested dynamic segment.
+ * `params` holds the parent segment's params, for example `{category: 'sci-fi'}` for
+ * `app/[category]/[slug]/page.tsx`.
+ * @public
+ */
+export interface GenerateStaticParamsArgs {
+  params?: StaticParams
+}
+
+/**
+ * @public
+ */
+export interface DefineGenerateStaticParamsOptions<Shape extends StaticParams> {
+  /**
+   * The client used to fetch documents at build time. It is reconfigured with
+   * `perspective: 'published'`, `useCdn: true`, and stega and source maps off, because
+   * route params are never rendered and cookies are unavailable during `next build`.
+   */
+  client: SanityClient
+  /**
+   * GROQ filter placed inside `*[...]`. Parent segment params are available as GROQ
+   * params, so `app/[category]/[slug]/page.tsx` can write
+   * `'_type == "post" && category->slug.current == $category'`.
+   */
+  filter: string
+  /**
+   * One GROQ expression per route param, evaluated against each matching document.
+   * The keys must match the keys of `fallback`; they become the param names.
+   * @example
+   * ```ts
+   * {slug: 'slug.current'}
+   * {category: 'category->slug.current', slug: 'slug.current'}
+   * {path: 'string::split(slug.current, "/")'}
+   * ```
+   */
+  params: {[Key in keyof NoInfer<Shape>]: string}
+  /**
+   * Returned as the only entry when the query yields no usable params, because
+   * Cache Components fails `next build` when `generateStaticParams` returns `[]`.
+   * Its shape also types the result. A `string` value declares a `[slug]` segment,
+   * a `string[]` value declares a `[...slug]` or `[[...slug]]` segment.
+   * Handle the placeholder in the page with `notFound()`.
+   */
+  fallback: Shape
+  /**
+   * Optional `order()` clause, for example `'_updatedAt desc'`.
+   */
+  order?: string
+  /**
+   * Optional cap on the number of documents, applied as `[0...limit]` after `order`.
+   * Prerendering only the most relevant pages keeps `next build` fast; the rest render on demand.
+   */
+  limit?: number
+}
+
+/**
+ * @public
+ */
+export interface DefinedGenerateStaticParams<Shape extends StaticParams> {
+  /**
+   * The assembled and syntax-checked GROQ query, for example
+   * `*[_type == "post"] | order(_updatedAt desc) [0...100]{"slug": slug.current}`.
+   * Useful for tests, or for fetching through `sanityFetch` when you want its cache tags.
+   */
+  query: string
+  /**
+   * Export this from the route file. Accepts the `{params}` argument Next.js passes to
+   * nested segments and forwards those params to GROQ as `$name` variables.
+   */
+  generateStaticParams: (args?: GenerateStaticParamsArgs) => Promise<Shape[]>
+}
+
+/**
+ * Returns `params` when it has at least one entry, otherwise `[fallback]`.
+ *
+ * Cache Components treats an empty `generateStaticParams` result as a build error, so a
+ * dynamic route must always prerender at least one path. The placeholder path should
+ * `notFound()` in the page.
+ *
+ * @example
+ * ```ts
+ * export async function generateStaticParams() {
+ *   return ensureStaticParams(await getArticleStaticParams(), {article: '_', section: '_'})
+ * }
+ * ```
+ * @public
+ */
+export function ensureStaticParams<T extends Record<string, null | string | string[]>>(
+  params: null | T[] | undefined,
+  fallback: NoInfer<T>,
+): T[] {
+  return params && params.length > 0 ? params : [fallback]
+}
+
+/**
+ * Builds a `generateStaticParams` for a dynamic route from a GROQ filter and one GROQ
+ * expression per route param.
+ *
+ * The query is assembled and parsed with `groq-js` when this function runs, which is at
+ * module evaluation of the route file, so `next build` fails fast with the offending
+ * expression and its position instead of a network error later in the build.
+ * Documents are fetched from the published perspective. Rows whose param values are
+ * `null` or of the wrong kind are dropped, duplicates are removed, and an empty result
+ * becomes `[fallback]` via {@link ensureStaticParams}.
+ *
+ * @example
+ * ```tsx
+ * // app/posts/[slug]/page.tsx
+ * import {defineGenerateStaticParams} from 'next-sanity/static-params'
+ * import {notFound} from 'next/navigation'
+ * import {client} from '@/sanity/client'
+ *
+ * export const {generateStaticParams} = defineGenerateStaticParams({
+ *   client,
+ *   filter: '_type == "post" && defined(slug.current)',
+ *   params: {slug: 'slug.current'},
+ *   fallback: {slug: '__placeholder__'},
+ *   order: '_updatedAt desc',
+ *   limit: 100,
+ * })
+ *
+ * export default async function Page({params}: PageProps<'/posts/[slug]'>) {
+ *   const {slug} = await params
+ *   if (slug === '__placeholder__') notFound()
+ *   // ...
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // app/[category]/[slug]/page.tsx, the parent segment's params arrive as GROQ params
+ * export const {generateStaticParams} = defineGenerateStaticParams({
+ *   client,
+ *   filter: '_type == "post" && category->slug.current == $category',
+ *   params: {slug: 'slug.current'},
+ *   fallback: {slug: '__placeholder__'},
+ * })
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // app/docs/[...path]/page.tsx, a `string[]` fallback declares a catch-all segment
+ * export const {generateStaticParams} = defineGenerateStaticParams({
+ *   client,
+ *   filter: '_type == "doc" && defined(slug.current)',
+ *   params: {path: 'string::split(slug.current, "/")'},
+ *   fallback: {path: ['__placeholder__']},
+ * })
+ * ```
+ * @public
+ */
+export function defineGenerateStaticParams<Shape extends StaticParams>(
+  options: DefineGenerateStaticParamsOptions<Shape>,
+): DefinedGenerateStaticParams<Shape> {
+  const {client, filter, params, fallback, order, limit} = options
+  const query = assembleQuery({filter, params, order, limit})
+
+  const staticClient = client.withConfig({
+    perspective: 'published',
+    useCdn: true,
+    stega: false,
+    resultSourceMap: false,
+  })
+
+  return {
+    query,
+    async generateStaticParams(args) {
+      const queryParams: QueryParams = args?.params ?? {}
+      const rows = await staticClient.fetch<unknown>(query, queryParams)
+      return ensureStaticParams(pickStaticParams(rows, fallback), fallback)
+    },
+  }
+}
+
+interface QueryPieces {
+  filter: string
+  params: Record<string, string>
+  order?: string | undefined
+  limit?: number | undefined
+}
+
+function assembleQuery({filter, params, order, limit}: QueryPieces): string {
+  assertGroq(filter, 'filter')
+  const keys = Object.keys(params)
+  if (keys.length === 0) {
+    throw new TypeError('defineGenerateStaticParams: `params` must declare at least one route param')
+  }
+  for (const key of keys) {
+    assertGroq(params[key]!, `params.${key}`)
+  }
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    throw new TypeError(
+      `defineGenerateStaticParams: \`limit\` must be a positive integer, got ${String(limit)}`,
+    )
+  }
+
+  const projection = keys.map((key) => `${JSON.stringify(key)}: ${params[key]}`).join(', ')
+  const pipe = order === undefined ? '' : ` | order(${order})`
+  const slice = limit === undefined ? '' : `[0...${limit}]`
+  const query = `*[${filter}]${pipe}${slice}{${projection}}`
+  assertGroq(query, 'query')
+  return query
+}
+
+function assertGroq(source: string, where: string): void {
+  try {
+    parse(source)
+  } catch (error) {
+    const position = error instanceof GroqSyntaxError ? ` at position ${error.position}` : ''
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `defineGenerateStaticParams: invalid GROQ in ${where}${position}\n  ${JSON.stringify(source)}\n  ${message}`,
+      {cause: error},
+    )
+  }
+}
+
+function pickStaticParams<Shape extends StaticParams>(rows: unknown, fallback: Shape): Shape[] {
+  if (!Array.isArray(rows)) {
+    throw new TypeError(
+      `defineGenerateStaticParams: expected the query to return an array, got ${typeof rows}`,
+    )
+  }
+  const keys = Object.keys(fallback)
+  const seen = new Set<string>()
+  const result: Shape[] = []
+  for (const row of rows) {
+    const picked = pickRow(row, keys, fallback)
+    if (picked === undefined) continue
+    const identity = JSON.stringify(picked)
+    if (seen.has(identity)) continue
+    seen.add(identity)
+    result.push(picked)
+  }
+  return result
+}
+
+function pickRow<Shape extends StaticParams>(
+  row: unknown,
+  keys: string[],
+  fallback: Shape,
+): Shape | undefined {
+  if (!isRecord(row)) return undefined
+  const picked: StaticParams = {}
+  for (const key of keys) {
+    const value = row[key]
+    if (!matchesKind(value, fallback[key]!)) return undefined
+    picked[key] = value
+  }
+  // Every key of `fallback` was checked against its declared kind, which is what `Shape` promises.
+  // oxlint-disable-next-line no-unsafe-type-assertion
+  return picked as Shape
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function matchesKind(value: unknown, sample: StaticParamValue): value is StaticParamValue {
+  if (Array.isArray(sample)) {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string')
+  }
+  return typeof value === 'string'
+}

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -199,10 +199,12 @@ function assembleQuery({filter, params, order, limit}: QueryPieces): string {
   assertGroq(filter, 'filter')
   const keys = Object.keys(params)
   if (keys.length === 0) {
-    throw new TypeError('defineGenerateStaticParams: `params` must declare at least one route param')
+    throw new TypeError(
+      'defineGenerateStaticParams: `params` must declare at least one route param',
+    )
   }
   for (const key of keys) {
-    assertGroq(params[key]!, `params.${key}`)
+    assertGroq(params[key], `params.${key}`)
   }
   if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
     throw new TypeError(
@@ -260,7 +262,7 @@ function pickRow<Shape extends StaticParams>(
   const picked: StaticParams = {}
   for (const key of keys) {
     const value = row[key]
-    if (!matchesKind(value, fallback[key]!)) return undefined
+    if (!matchesKind(value, fallback[key])) return undefined
     picked[key] = value
   }
   // Every key of `fallback` was checked against its declared kind, which is what `Shape` promises.

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -251,12 +251,12 @@ function pickStaticParams<Shape extends StaticParams>(rows: unknown, fallback: S
       `defineGenerateStaticParams: expected the query to return an array, got ${typeof rows}`,
     )
   }
-  const keys = Object.keys(fallback)
   const seen = new Set<string>()
   const result: Shape[] = []
   for (const row of rows) {
-    const picked = pickRow(row, keys, fallback)
-    if (picked === undefined) continue
+    if (!isRecord(row)) continue
+    const picked = pickKeys(row, fallback)
+    if (!hasShape(picked, fallback)) continue
     const identity = JSON.stringify(picked)
     if (seen.has(identity)) continue
     seen.add(identity)
@@ -265,21 +265,19 @@ function pickStaticParams<Shape extends StaticParams>(rows: unknown, fallback: S
   return result
 }
 
-function pickRow<Shape extends StaticParams>(
-  row: unknown,
-  keys: string[],
-  fallback: Shape,
-): Shape | undefined {
-  if (!isRecord(row)) return undefined
-  const picked: StaticParams = {}
-  for (const key of keys) {
-    const value = row[key]
-    if (!isRoutableValue(value, fallback[key])) return undefined
-    picked[key] = value
+function pickKeys(row: Record<string, unknown>, sample: StaticParams): Record<string, unknown> {
+  const picked: Record<string, unknown> = {}
+  for (const key of Object.keys(sample)) {
+    picked[key] = row[key]
   }
-  // Every key of `fallback` was checked against its declared kind, which is what `Shape` promises.
-  // oxlint-disable-next-line no-unsafe-type-assertion
-  return picked as Shape
+  return picked
+}
+
+function hasShape<Shape extends StaticParams>(
+  value: Record<string, unknown>,
+  sample: Shape,
+): value is Shape {
+  return Object.keys(sample).every((key) => isRoutableValue(value[key], sample[key]))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -291,9 +289,8 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /**
- * `sample` decides the kind, `value` is what has to fit it. Empty strings and
- * empty arrays never fit, since Next.js cannot route to an empty segment and a
- * `[...slug]` route given `[]` would resolve to the parent path.
+ * Next.js only checks that a `[...slug]` value is an array and a `[slug]` value is a
+ * string, so `''` and `[]` pass its validation and would prerender an empty segment.
  */
 function isRoutableValue(value: unknown, sample: StaticParamValue): value is StaticParamValue {
   if (Array.isArray(sample)) {

--- a/packages/next-sanity/src/static-params/index.ts
+++ b/packages/next-sanity/src/static-params/index.ts
@@ -231,15 +231,11 @@ export function defineGenerateStaticParams<Shape extends StaticParams = Record<s
   }
 }
 
-/**
- * One top-level `&&` conjunct of the page query's root filter, in source order.
- * A binding is `<expr> == $param`. Everything else is a constraint.
- */
 type Conjunct = {kind: 'constraint'; groq: string} | {kind: 'binding'; param: string; expr: string}
 
 /**
- * groq-js 2.0.0 ships no declarations for its AST nodes, so these name the few shapes
- * the walk inspects. Every other node only matters as an opaque subtree.
+ * groq-js 2.0.0 publishes no declarations for its AST nodes, so the walk names the
+ * five shapes it inspects.
  */
 interface GroqNode {
   type: string
@@ -308,10 +304,8 @@ function inferStaticParamsQuery(query: string): Conjunct[] {
 }
 
 /**
- * Walks down the `base` chain from the query root to the filter that sits on `*`, and
- * returns the `expr` of every filter in that chain, outermost last. `*[A][B]` reads as
- * `*[A && B]`. A filter that sits on anything else, such as `*[A]{...}[B]`, is rejected
- * because `B` would refer to the projected shape.
+ * `*[A][B]` reads as `*[A && B]`. A filter after a projection, `*[A]{...}[B]`, would
+ * refer to the projected shape, so it is rejected.
  */
 function rootFilterExprs(root: GroqNode): GroqNode[] {
   let node: GroqNode | undefined = root

--- a/packages/next-sanity/test/defineGenerateStaticParams.test.ts
+++ b/packages/next-sanity/test/defineGenerateStaticParams.test.ts
@@ -163,6 +163,26 @@ describe('definition-time validation', () => {
       }),
     ).toThrow(/`limit` must be a positive integer, got 0/)
   })
+
+  test.each([{slug: ''}, {path: []}, {path: ['']}, {path: ['ok', '']}, {category: 'ok', slug: ''}])(
+    'rejects the fallback %j at definition time',
+    (fallback) => {
+      const {client} = createFakeClient()
+      const key = Object.keys(fallback).at(-1)
+      expect(() =>
+        defineGenerateStaticParams({
+          client,
+          filter: '_type == "post"',
+          params: Object.fromEntries(Object.keys(fallback).map((name) => [name, 'slug.current'])),
+          fallback,
+        }),
+      ).toThrow(
+        new TypeError(
+          `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
+        ),
+      )
+    },
+  )
 })
 
 describe('generateStaticParams', () => {
@@ -238,6 +258,37 @@ describe('generateStaticParams', () => {
       fallback: {slug: '_'},
     })
     await expect(generateStaticParams()).resolves.toEqual([{slug: 'ok'}, {slug: 'ok-2'}])
+  })
+
+  test('drops rows with an empty string or an empty catch-all', async () => {
+    const {client} = createFakeClient([{slug: ''}, {slug: 'ok'}])
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    await expect(generateStaticParams()).resolves.toEqual([{slug: 'ok'}])
+
+    const catchAll = createFakeClient([{path: []}, {path: ['a', '']}, {path: ['a', 'b']}])
+    const docs = defineGenerateStaticParams({
+      client: catchAll.client,
+      filter: '_type == "doc"',
+      params: {path: 'string::split(slug.current, "/")'},
+      fallback: {path: ['_']},
+    })
+    await expect(docs.generateStaticParams()).resolves.toEqual([{path: ['a', 'b']}])
+  })
+
+  test('returns the fallback when only empty catch-alls match', async () => {
+    const {client} = createFakeClient([{path: []}])
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "doc"',
+      params: {path: 'string::split(slug.current, "/")'},
+      fallback: {path: ['__placeholder__']},
+    })
+    await expect(generateStaticParams()).resolves.toEqual([{path: ['__placeholder__']}])
   })
 
   test('returns the fallback when nothing matches', async () => {

--- a/packages/next-sanity/test/defineGenerateStaticParams.test.ts
+++ b/packages/next-sanity/test/defineGenerateStaticParams.test.ts
@@ -132,7 +132,7 @@ describe('query inference', () => {
     const {query} = defineGenerateStaticParams({
       client,
       query:
-        '*[_type == "post" && slug.current == $slug][0]{title, "related": *[_type == "post" && slug.current != $slug][0...$limit]{title}}',
+        '*[_type == "post" && slug.current == $slug][0]{title, "related": *[_type == "post" && slug.current != $slug && language == $locale][0...3]{title}}',
     })
     expect(query).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
   })
@@ -158,11 +158,11 @@ describe('definition-time validation', () => {
       defineGenerateStaticParams({client, query: '*[_type == "post" && slug.current == $slug!!]'})
       expect.unreachable()
     } catch (error) {
-      expect(error).toMatchObject({cause: {name: 'GroqSyntaxError', position: 42}})
+      expect(error).toMatchObject({cause: {name: 'GroqSyntaxError', position: 41}})
       expect(error).toMatchInlineSnapshot(`
-        [Error: defineGenerateStaticParams: invalid GROQ in query at position 42
+        [Error: defineGenerateStaticParams: invalid GROQ in query at position 41
           "*[_type == \\"post\\" && slug.current == $slug!!]"
-          Syntax error in GROQ query at position 42: Unexpected end of query]
+          Syntax error in GROQ query at position 41: Unexpected end of query]
       `)
     }
   })
@@ -178,6 +178,7 @@ describe('definition-time validation', () => {
       '(slug.current == $slug || _id == $slug)',
     ],
     ['*[_type == "post" && slug.current == $slug + $suffix][0]', 'slug.current == $slug + $suffix'],
+    ['*[_type == "post" && $slug == slug.current + $suffix][0]', '$slug == slug.current + $suffix'],
   ])('rejects a $param that is not bound with == in %s', (query, offending) => {
     const {client} = createFakeClient()
     expect(() => defineGenerateStaticParams({client, query})).toThrow(

--- a/packages/next-sanity/test/defineGenerateStaticParams.test.ts
+++ b/packages/next-sanity/test/defineGenerateStaticParams.test.ts
@@ -1,12 +1,28 @@
 import type {ClientConfig, SanityClient} from '@sanity/client'
 import {evaluate, parse} from 'groq-js'
-import {defineGenerateStaticParams, type StaticParams} from 'next-sanity/static-params'
+import {
+  defineGenerateStaticParams,
+  STATIC_PARAMS_PLACEHOLDER,
+  type StaticParams,
+} from 'next-sanity/static-params'
 import {describe, expect, expectTypeOf, test, vi} from 'vitest'
 
 const dataset = [
-  {_id: 'a', _type: 'post', slug: {current: 'aliens'}, category: {_ref: 'sci-fi'}},
+  {
+    _id: 'a',
+    _type: 'post',
+    slug: {current: 'aliens'},
+    category: {_ref: 'sci-fi'},
+    publishedAt: '1979-05-25',
+  },
   {_id: 'b', _type: 'post', slug: {current: 'prometheus'}, category: {_ref: 'sci-fi'}},
-  {_id: 'c', _type: 'post', slug: {current: 'aliens'}, category: {_ref: 'horror'}},
+  {
+    _id: 'c',
+    _type: 'post',
+    slug: {current: 'aliens'},
+    category: {_ref: 'horror'},
+    publishedAt: '1986-07-18',
+  },
   {_id: 'd', _type: 'post', category: {_ref: 'sci-fi'}},
   {_id: 'e', _type: 'author', slug: {current: 'ridley-scott'}},
   {_id: 'sci-fi', _type: 'category', slug: {current: 'sci-fi'}},
@@ -14,6 +30,10 @@ const dataset = [
   {_id: 'doc-1', _type: 'doc', slug: {current: 'guides/getting-started'}},
   {_id: 'doc-2', _type: 'doc', slug: {current: 'reference'}},
 ]
+
+const postQuery = `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`
+const categoryPostQuery = `*[_type == "post" && category->slug.current == $category && slug.current == $slug][0]{title}`
+const docQuery = `*[_type == "doc" && string::split(slug.current, "/") == $path][0]{title}`
 
 function createFakeClient(rows?: unknown) {
   const withConfig = vi.fn()
@@ -28,140 +48,202 @@ function createFakeClient(rows?: unknown) {
   return {client: client as unknown as SanityClient, withConfig, fetch}
 }
 
-describe('query assembly', () => {
-  test('single param', () => {
+describe('query inference', () => {
+  test('a single binding drops [0] and the projection and keeps the type constraint', () => {
     const {client} = createFakeClient()
-    const {query} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
-    expect(query).toBe('*[_type == "post"]{"slug": slug.current}')
+    const {query} = defineGenerateStaticParams({client, query: postQuery})
+    expect(query).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
   })
 
-  test('multiple params keep declaration order', () => {
+  test('two bindings, one through a dereference', () => {
     const {client} = createFakeClient()
-    const {query} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {category: 'category->slug.current', slug: 'slug.current'},
-      fallback: {category: '_', slug: '_'},
-    })
+    const {query} = defineGenerateStaticParams({client, query: categoryPostQuery})
     expect(query).toBe(
-      '*[_type == "post"]{"category": category->slug.current, "slug": slug.current}',
+      '*[_type == "post" && defined(category->.slug.current) && defined(slug.current)]{"category": category->.slug.current, "slug": slug.current}',
     )
   })
 
-  test('catch-all param', () => {
+  test('the param may sit on the left side of ==', () => {
     const {client} = createFakeClient()
     const {query} = defineGenerateStaticParams({
       client,
-      filter: '_type == "doc"',
-      params: {path: 'string::split(slug.current, "/")'},
-      fallback: {path: ['_']},
+      query: '*[_type == "post" && $slug == slug.current][0]',
     })
-    expect(query).toBe('*[_type == "doc"]{"path": string::split(slug.current, "/")}')
+    expect(query).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
+  })
+
+  test('a computed binding keeps the whole expression', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      query: docQuery,
+      fallback: {path: [STATIC_PARAMS_PLACEHOLDER]},
+    })
+    expect(query).toBe(
+      '*[_type == "doc" && defined(string::split(slug.current, "/"))]{"path": string::split(slug.current, "/")}',
+    )
+  })
+
+  test('non-binding conjuncts stay in the filter, printed by groq-js', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      query:
+        '*[_type == "post" && defined(publishedAt) && publishedAt < now() && !(_id in path("drafts.**")) && slug.current == $slug][0]{title}',
+    })
+    expect(query).toBe(
+      '*[_type == "post" && global::defined(publishedAt) && publishedAt < global::now() && !(_id in global::path("drafts.**")) && defined(slug.current)]{"slug": slug.current}',
+    )
+    expect(parse(query)).toEqual(
+      parse(
+        '*[_type == "post" && defined(publishedAt) && publishedAt < now() && !(_id in path("drafts.**")) && defined(slug.current)]{"slug": slug.current}',
+      ),
+    )
+  })
+
+  test('a parenthesized binding and chained filters are accepted', () => {
+    const {client} = createFakeClient()
+    expect(
+      defineGenerateStaticParams({
+        client,
+        query: '*[_type == "post" && (slug.current == $slug)][0]',
+      }).query,
+    ).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
+    expect(
+      defineGenerateStaticParams({
+        client,
+        query: '*[_type == "post"][slug.current == $slug][0]{title}',
+      }).query,
+    ).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
+  })
+
+  test('the page order, slice, and attribute access after the filter are dropped', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      query:
+        '*[_type == "post" && slug.current == $slug] | order(publishedAt desc)[0...10]{title}.title',
+    })
+    expect(query).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
+  })
+
+  test('params outside the root filter are ignored because that part is dropped', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      query:
+        '*[_type == "post" && slug.current == $slug][0]{title, "related": *[_type == "post" && slug.current != $slug][0...$limit]{title}}',
+    })
+    expect(query).toBe('*[_type == "post" && defined(slug.current)]{"slug": slug.current}')
   })
 
   test('order and limit', () => {
     const {client} = createFakeClient()
     const {query} = defineGenerateStaticParams({
       client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
+      query: postQuery,
       order: '_updatedAt desc',
       limit: 100,
     })
-    expect(query).toBe('*[_type == "post"] | order(_updatedAt desc)[0...100]{"slug": slug.current}')
+    expect(query).toBe(
+      '*[_type == "post" && defined(slug.current)] | order(_updatedAt desc)[0...100]{"slug": slug.current}',
+    )
   })
 })
 
 describe('definition-time validation', () => {
-  test('syntax error in a param expression names the key, expression, and position', () => {
-    const {client} = createFakeClient()
-    expect(() =>
-      defineGenerateStaticParams({
-        client,
-        filter: '_type == "post"',
-        params: {slug: 'slug.current!!'},
-        fallback: {slug: '_'},
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      [Error: defineGenerateStaticParams: invalid GROQ in params.slug at position 11
-        "slug.current!!"
-        Syntax error in GROQ query at position 11: Unexpected end of query]
-    `)
-  })
-
-  test('syntax error in the filter', () => {
-    const {client} = createFakeClient()
-    expect(() =>
-      defineGenerateStaticParams({
-        client,
-        filter: '_type == "post" &&',
-        params: {slug: 'slug.current'},
-        fallback: {slug: '_'},
-      }),
-    ).toThrow(/invalid GROQ in filter at position 18\n {2}"_type == \\"post\\" &&"/)
-  })
-
-  test('a param expression that would escape the projection is rejected on its own', () => {
-    const {client} = createFakeClient()
-    expect(() =>
-      defineGenerateStaticParams({
-        client,
-        filter: '_type == "post"',
-        params: {slug: 'slug.current}, "x": 1'},
-        fallback: {slug: '_'},
-      }),
-    ).toThrow(/invalid GROQ in params\.slug/)
-  })
-
-  test('syntax error in order is reported on the assembled query', () => {
-    const {client} = createFakeClient()
-    expect(() =>
-      defineGenerateStaticParams({
-        client,
-        filter: '_type == "post"',
-        params: {slug: 'slug.current'},
-        fallback: {slug: '_'},
-        order: 'desc _updatedAt',
-      }),
-    ).toThrow(/invalid GROQ in query/)
-  })
-
-  test('the thrown error keeps the GroqSyntaxError as cause', () => {
+  test('a syntax error names the position and keeps the GroqSyntaxError as cause', () => {
     const {client} = createFakeClient()
     try {
-      defineGenerateStaticParams({
-        client,
-        filter: '',
-        params: {slug: 'slug.current'},
-        fallback: {slug: '_'},
-      })
+      defineGenerateStaticParams({client, query: '*[_type == "post" && slug.current == $slug!!]'})
       expect.unreachable()
     } catch (error) {
-      expect(error).toBeInstanceOf(Error)
-      expect(error).toMatchObject({cause: {name: 'GroqSyntaxError', position: 0}})
+      expect(error).toMatchObject({cause: {name: 'GroqSyntaxError', position: 42}})
+      expect(error).toMatchInlineSnapshot(`
+        [Error: defineGenerateStaticParams: invalid GROQ in query at position 42
+          "*[_type == \\"post\\" && slug.current == $slug!!]"
+          Syntax error in GROQ query at position 42: Unexpected end of query]
+      `)
     }
   })
 
-  test('rejects an empty params object and a non-positive limit', () => {
+  test.each([
+    ['*[_type == "post" && slug.current match $slug][0]', 'slug.current match $slug'],
+    [
+      '*[_type == "post" && references($ref) && slug.current == $slug][0]',
+      'global::references($ref)',
+    ],
+    [
+      '*[_type == "post" && (slug.current == $slug || _id == $slug)][0]',
+      '(slug.current == $slug || _id == $slug)',
+    ],
+    ['*[_type == "post" && slug.current == $slug + $suffix][0]', 'slug.current == $slug + $suffix'],
+  ])('rejects a $param that is not bound with == in %s', (query, offending) => {
+    const {client} = createFakeClient()
+    expect(() => defineGenerateStaticParams({client, query})).toThrow(
+      `defineGenerateStaticParams: every $param in the root filter must be bound as \`<expression> == $param\` in a top-level &&, found ${offending}`,
+    )
+  })
+
+  test('rejects a binding between two params', () => {
     const {client} = createFakeClient()
     expect(() =>
-      defineGenerateStaticParams({client, filter: '_type == "post"', params: {}, fallback: {}}),
-    ).toThrow(TypeError)
+      defineGenerateStaticParams({client, query: '*[_type == "post" && $a == $b][0]'}),
+    ).toThrow('defineGenerateStaticParams: `$a == $b` binds a param to another param')
+  })
+
+  test('rejects a param bound twice', () => {
+    const {client} = createFakeClient()
     expect(() =>
       defineGenerateStaticParams({
         client,
-        filter: '_type == "post"',
-        params: {slug: 'slug.current'},
-        fallback: {slug: '_'},
-        limit: 0,
+        query: '*[_type == "post" && slug.current == $slug && _id == $slug][0]',
       }),
-    ).toThrow(/`limit` must be a positive integer, got 0/)
+    ).toThrow('defineGenerateStaticParams: `$slug` is bound twice, by slug.current and _id')
+  })
+
+  test.each([
+    '*[_type == "post"][0]',
+    '*[_type == "post" && defined(slug.current)]{"slug": slug.current}',
+  ])('rejects a query without bindings: %s', (query) => {
+    const {client} = createFakeClient()
+    expect(() => defineGenerateStaticParams({client, query})).toThrow(
+      'defineGenerateStaticParams: the query binds no $param, add a conjunct such as `slug.current == $slug`',
+    )
+  })
+
+  test.each([
+    '{"post": *[_type == "post" && slug.current == $slug][0]}',
+    '*{title}',
+    '*[_type == "post"]{title}[slug.current == $slug][0]',
+  ])('rejects a query that does not start with a filter on *: %s', (query) => {
+    const {client} = createFakeClient()
+    expect(() => defineGenerateStaticParams({client, query})).toThrow(
+      'defineGenerateStaticParams: the query must start with `*[...]`',
+    )
+  })
+
+  test('rejects an order clause that does not parse', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({client, query: postQuery, order: 'desc _updatedAt'}),
+    ).toThrow(/invalid GROQ in query/)
+  })
+
+  test('rejects a non-positive limit', () => {
+    const {client} = createFakeClient()
+    expect(() => defineGenerateStaticParams({client, query: postQuery, limit: 0})).toThrow(
+      '`limit` must be a positive integer, got 0',
+    )
+  })
+
+  test('rejects a fallback key that is not a bound param', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({client, query: postQuery, fallback: {slugg: 'x'}}),
+    ).toThrow(
+      'defineGenerateStaticParams: `fallback.slugg` does not match a $param, bound params: slug',
+    )
   })
 
   test.each<StaticParams>([
@@ -172,15 +254,10 @@ describe('definition-time validation', () => {
     {category: 'ok', slug: ''},
   ])('rejects the fallback %j at definition time', (fallback) => {
     const {client} = createFakeClient()
-    const key = Object.keys(fallback).at(-1)
-    expect(() =>
-      defineGenerateStaticParams({
-        client,
-        filter: '_type == "post"',
-        params: Object.fromEntries(Object.keys(fallback).map((name) => [name, 'slug.current'])),
-        fallback,
-      }),
-    ).toThrow(
+    const params = Object.keys(fallback)
+    const key = params.at(-1)
+    const query = `*[_type == "post" && ${params.map((name) => `slug.current == $${name}`).join(' && ')}][0]`
+    expect(() => defineGenerateStaticParams({client, query, fallback})).toThrow(
       new TypeError(
         `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
       ),
@@ -191,12 +268,7 @@ describe('definition-time validation', () => {
 describe('generateStaticParams', () => {
   test('reconfigures the client for build-time reads', () => {
     const {client, withConfig} = createFakeClient()
-    defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
+    defineGenerateStaticParams({client, query: postQuery})
     expect(withConfig).toHaveBeenCalledExactlyOnceWith({
       perspective: 'published',
       useCdn: true,
@@ -207,25 +279,33 @@ describe('generateStaticParams', () => {
 
   test('maps documents to params, drops null values, and removes duplicates', async () => {
     const {client} = createFakeClient()
-    const {generateStaticParams} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
     const result = await generateStaticParams()
-    expectTypeOf(result).toEqualTypeOf<{slug: string}[]>()
+    expectTypeOf(result).toEqualTypeOf<Record<string, string>[]>()
     expect(result).toEqual([{slug: 'aliens'}, {slug: 'prometheus'}])
   })
 
-  test('keeps duplicate slugs apart when another param differs', async () => {
+  test('the Shape generic types the result', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams<{slug: string}>({
+      client,
+      query: postQuery,
+    })
+    expectTypeOf(await generateStaticParams()).toEqualTypeOf<{slug: string}[]>()
+  })
+
+  test('kept conjuncts run against the dataset', async () => {
     const {client} = createFakeClient()
     const {generateStaticParams} = defineGenerateStaticParams({
       client,
-      filter: '_type == "post"',
-      params: {category: 'category->slug.current', slug: 'slug.current'},
-      fallback: {category: '_', slug: '_'},
+      query: '*[_type == "post" && defined(publishedAt) && slug.current == $slug][0]{title}',
     })
+    await expect(generateStaticParams()).resolves.toEqual([{slug: 'aliens'}])
+  })
+
+  test('without parent params every binding is emitted', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: categoryPostQuery})
     await expect(generateStaticParams()).resolves.toEqual([
       {category: 'sci-fi', slug: 'aliens'},
       {category: 'sci-fi', slug: 'prometheus'},
@@ -233,20 +313,52 @@ describe('generateStaticParams', () => {
     ])
   })
 
-  test('catch-all params are arrays of strings', async () => {
+  test('a parent param turns its binding into a constraint', async () => {
+    const {client, fetch} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: categoryPostQuery})
+    await expect(generateStaticParams({params: {category: 'horror'}})).resolves.toEqual([
+      {slug: 'aliens'},
+    ])
+    expect(fetch).toHaveBeenLastCalledWith(
+      '*[_type == "post" && category->.slug.current == $category && defined(slug.current)]{"slug": slug.current}',
+      {category: 'horror'},
+    )
+    await expect(generateStaticParams({params: {category: 'drama'}})).resolves.toEqual([
+      {slug: STATIC_PARAMS_PLACEHOLDER},
+    ])
+  })
+
+  test('parent params that are not bound in the query are ignored', async () => {
+    const {client, fetch} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
+    await expect(generateStaticParams({params: {perspective: 'published'}})).resolves.toEqual([
+      {slug: 'aliens'},
+      {slug: 'prometheus'},
+    ])
+    expect(fetch).toHaveBeenLastCalledWith(expect.any(String), {})
+  })
+
+  test('rejects a call whose parent params cover every binding', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
+    await expect(generateStaticParams({params: {slug: 'aliens'}})).rejects.toThrow(
+      'defineGenerateStaticParams: the parent params already bind every $param, nothing is left to generate',
+    )
+  })
+
+  test('catch-all params are arrays of strings when the fallback says so', async () => {
     const {client} = createFakeClient()
     const {generateStaticParams} = defineGenerateStaticParams({
       client,
-      filter: '_type == "doc"',
-      params: {path: 'string::split(slug.current, "/")'},
-      fallback: {path: ['_']},
+      query: docQuery,
+      fallback: {path: [STATIC_PARAMS_PLACEHOLDER]},
     })
     const result = await generateStaticParams()
     expectTypeOf(result).toEqualTypeOf<{path: string[]}[]>()
     expect(result).toEqual([{path: ['guides', 'getting-started']}, {path: ['reference']}])
   })
 
-  test('drops rows whose value has the wrong kind for the declared fallback', async () => {
+  test('drops rows whose value has the wrong kind for the fallback', async () => {
     const {client} = createFakeClient([
       {slug: 'ok'},
       {slug: ['not', 'a', 'string']},
@@ -254,82 +366,47 @@ describe('generateStaticParams', () => {
       null,
       {slug: 'ok-2'},
     ])
-    const {generateStaticParams} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
     await expect(generateStaticParams()).resolves.toEqual([{slug: 'ok'}, {slug: 'ok-2'}])
   })
 
   test('drops rows with an empty string or an empty catch-all', async () => {
     const {client} = createFakeClient([{slug: ''}, {slug: 'ok'}])
-    const {generateStaticParams} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
     await expect(generateStaticParams()).resolves.toEqual([{slug: 'ok'}])
 
     const catchAll = createFakeClient([{path: []}, {path: ['a', '']}, {path: ['a', 'b']}])
     const docs = defineGenerateStaticParams({
       client: catchAll.client,
-      filter: '_type == "doc"',
-      params: {path: 'string::split(slug.current, "/")'},
+      query: docQuery,
       fallback: {path: ['_']},
     })
     await expect(docs.generateStaticParams()).resolves.toEqual([{path: ['a', 'b']}])
   })
 
-  test('returns the fallback when only empty catch-alls match', async () => {
-    const {client} = createFakeClient([{path: []}])
-    const {generateStaticParams} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "doc"',
-      params: {path: 'string::split(slug.current, "/")'},
-      fallback: {path: ['__placeholder__']},
-    })
-    await expect(generateStaticParams()).resolves.toEqual([{path: ['__placeholder__']}])
-  })
-
-  test('returns the fallback when nothing matches', async () => {
+  test('returns the placeholder when nothing matches', async () => {
     const {client} = createFakeClient()
     const {generateStaticParams} = defineGenerateStaticParams({
       client,
-      filter: '_type == "movie"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '__placeholder__'},
+      query: '*[_type == "movie" && slug.current == $slug][0]',
     })
     await expect(generateStaticParams()).resolves.toEqual([{slug: '__placeholder__'}])
+    expect(STATIC_PARAMS_PLACEHOLDER).toBe('__placeholder__')
   })
 
-  test('forwards parent segment params as GROQ params', async () => {
-    const {client, fetch} = createFakeClient()
+  test('returns the explicit fallback when nothing matches', async () => {
+    const {client} = createFakeClient([{path: []}])
     const {generateStaticParams} = defineGenerateStaticParams({
       client,
-      filter: '_type == "post" && category->slug.current == $category',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '__placeholder__'},
+      query: docQuery,
+      fallback: {path: ['nothing', 'here']},
     })
-    await expect(generateStaticParams({params: {category: 'horror'}})).resolves.toEqual([
-      {slug: 'aliens'},
-    ])
-    await expect(generateStaticParams({params: {category: 'drama'}})).resolves.toEqual([
-      {slug: '__placeholder__'},
-    ])
-    expect(fetch).toHaveBeenLastCalledWith(expect.any(String), {category: 'drama'})
+    await expect(generateStaticParams()).resolves.toEqual([{path: ['nothing', 'here']}])
   })
 
   test('throws when the query result is not an array', async () => {
     const {client} = createFakeClient({slug: 'not-a-list'})
-    const {generateStaticParams} = defineGenerateStaticParams({
-      client,
-      filter: '_type == "post"',
-      params: {slug: 'slug.current'},
-      fallback: {slug: '_'},
-    })
+    const {generateStaticParams} = defineGenerateStaticParams({client, query: postQuery})
     await expect(generateStaticParams()).rejects.toThrow(
       'expected the query to return an array, got object',
     )

--- a/packages/next-sanity/test/defineGenerateStaticParams.test.ts
+++ b/packages/next-sanity/test/defineGenerateStaticParams.test.ts
@@ -1,0 +1,283 @@
+import type {ClientConfig, SanityClient} from '@sanity/client'
+import {evaluate, parse} from 'groq-js'
+import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {describe, expect, expectTypeOf, test, vi} from 'vitest'
+
+const dataset = [
+  {_id: 'a', _type: 'post', slug: {current: 'aliens'}, category: {_ref: 'sci-fi'}},
+  {_id: 'b', _type: 'post', slug: {current: 'prometheus'}, category: {_ref: 'sci-fi'}},
+  {_id: 'c', _type: 'post', slug: {current: 'aliens'}, category: {_ref: 'horror'}},
+  {_id: 'd', _type: 'post', category: {_ref: 'sci-fi'}},
+  {_id: 'e', _type: 'author', slug: {current: 'ridley-scott'}},
+  {_id: 'sci-fi', _type: 'category', slug: {current: 'sci-fi'}},
+  {_id: 'horror', _type: 'category', slug: {current: 'horror'}},
+  {_id: 'doc-1', _type: 'doc', slug: {current: 'guides/getting-started'}},
+  {_id: 'doc-2', _type: 'doc', slug: {current: 'reference'}},
+]
+
+function createFakeClient(rows?: unknown) {
+  const withConfig = vi.fn()
+  const fetch = vi.fn(async (query: string, params: Record<string, unknown>) => {
+    if (rows !== undefined) return rows
+    const value = await evaluate(parse(query), {dataset, params})
+    return value.get()
+  })
+  const client = {withConfig, fetch}
+  withConfig.mockReturnValue(client)
+  // oxlint-disable-next-line no-unsafe-type-assertion
+  return {client: client as unknown as SanityClient, withConfig, fetch}
+}
+
+describe('query assembly', () => {
+  test('single param', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    expect(query).toBe('*[_type == "post"]{"slug": slug.current}')
+  })
+
+  test('multiple params keep declaration order', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {category: 'category->slug.current', slug: 'slug.current'},
+      fallback: {category: '_', slug: '_'},
+    })
+    expect(query).toBe(
+      '*[_type == "post"]{"category": category->slug.current, "slug": slug.current}',
+    )
+  })
+
+  test('catch-all param', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "doc"',
+      params: {path: 'string::split(slug.current, "/")'},
+      fallback: {path: ['_']},
+    })
+    expect(query).toBe('*[_type == "doc"]{"path": string::split(slug.current, "/")}')
+  })
+
+  test('order and limit', () => {
+    const {client} = createFakeClient()
+    const {query} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+      order: '_updatedAt desc',
+      limit: 100,
+    })
+    expect(query).toBe('*[_type == "post"] | order(_updatedAt desc)[0...100]{"slug": slug.current}')
+  })
+})
+
+describe('definition-time validation', () => {
+  test('syntax error in a param expression names the key, expression, and position', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post"',
+        params: {slug: 'slug.current!!'},
+        fallback: {slug: '_'},
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: defineGenerateStaticParams: invalid GROQ in params.slug at position 11
+        "slug.current!!"
+        Syntax error in GROQ query at position 11: Unexpected end of query]
+    `)
+  })
+
+  test('syntax error in the filter', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post" &&',
+        params: {slug: 'slug.current'},
+        fallback: {slug: '_'},
+      }),
+    ).toThrow(/invalid GROQ in filter at position 18\n {2}"_type == \\"post\\" &&"/)
+  })
+
+  test('a param expression that would escape the projection is rejected on its own', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post"',
+        params: {slug: 'slug.current}, "x": 1'},
+        fallback: {slug: '_'},
+      }),
+    ).toThrow(/invalid GROQ in params\.slug/)
+  })
+
+  test('syntax error in order is reported on the assembled query', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post"',
+        params: {slug: 'slug.current'},
+        fallback: {slug: '_'},
+        order: 'desc _updatedAt',
+      }),
+    ).toThrow(/invalid GROQ in query/)
+  })
+
+  test('the thrown error keeps the GroqSyntaxError as cause', () => {
+    const {client} = createFakeClient()
+    try {
+      defineGenerateStaticParams({
+        client,
+        filter: '',
+        params: {slug: 'slug.current'},
+        fallback: {slug: '_'},
+      })
+      expect.unreachable()
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toMatchObject({cause: {name: 'GroqSyntaxError', position: 0}})
+    }
+  })
+
+  test('rejects an empty params object and a non-positive limit', () => {
+    const {client} = createFakeClient()
+    expect(() =>
+      defineGenerateStaticParams({client, filter: '_type == "post"', params: {}, fallback: {}}),
+    ).toThrow(TypeError)
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post"',
+        params: {slug: 'slug.current'},
+        fallback: {slug: '_'},
+        limit: 0,
+      }),
+    ).toThrow(/`limit` must be a positive integer, got 0/)
+  })
+})
+
+describe('generateStaticParams', () => {
+  test('reconfigures the client for build-time reads', () => {
+    const {client, withConfig} = createFakeClient()
+    defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    expect(withConfig).toHaveBeenCalledExactlyOnceWith({
+      perspective: 'published',
+      useCdn: true,
+      stega: false,
+      resultSourceMap: false,
+    } satisfies ClientConfig)
+  })
+
+  test('maps documents to params, drops null values, and removes duplicates', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    const result = await generateStaticParams()
+    expectTypeOf(result).toEqualTypeOf<{slug: string}[]>()
+    expect(result).toEqual([{slug: 'aliens'}, {slug: 'prometheus'}])
+  })
+
+  test('keeps duplicate slugs apart when another param differs', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {category: 'category->slug.current', slug: 'slug.current'},
+      fallback: {category: '_', slug: '_'},
+    })
+    await expect(generateStaticParams()).resolves.toEqual([
+      {category: 'sci-fi', slug: 'aliens'},
+      {category: 'sci-fi', slug: 'prometheus'},
+      {category: 'horror', slug: 'aliens'},
+    ])
+  })
+
+  test('catch-all params are arrays of strings', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "doc"',
+      params: {path: 'string::split(slug.current, "/")'},
+      fallback: {path: ['_']},
+    })
+    const result = await generateStaticParams()
+    expectTypeOf(result).toEqualTypeOf<{path: string[]}[]>()
+    expect(result).toEqual([{path: ['guides', 'getting-started']}, {path: ['reference']}])
+  })
+
+  test('drops rows whose value has the wrong kind for the declared fallback', async () => {
+    const {client} = createFakeClient([
+      {slug: 'ok'},
+      {slug: ['not', 'a', 'string']},
+      {slug: 42},
+      null,
+      {slug: 'ok-2'},
+    ])
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    await expect(generateStaticParams()).resolves.toEqual([{slug: 'ok'}, {slug: 'ok-2'}])
+  })
+
+  test('returns the fallback when nothing matches', async () => {
+    const {client} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "movie"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '__placeholder__'},
+    })
+    await expect(generateStaticParams()).resolves.toEqual([{slug: '__placeholder__'}])
+  })
+
+  test('forwards parent segment params as GROQ params', async () => {
+    const {client, fetch} = createFakeClient()
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post" && category->slug.current == $category',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '__placeholder__'},
+    })
+    await expect(generateStaticParams({params: {category: 'horror'}})).resolves.toEqual([
+      {slug: 'aliens'},
+    ])
+    await expect(generateStaticParams({params: {category: 'drama'}})).resolves.toEqual([
+      {slug: '__placeholder__'},
+    ])
+    expect(fetch).toHaveBeenLastCalledWith(expect.any(String), {category: 'drama'})
+  })
+
+  test('throws when the query result is not an array', async () => {
+    const {client} = createFakeClient({slug: 'not-a-list'})
+    const {generateStaticParams} = defineGenerateStaticParams({
+      client,
+      filter: '_type == "post"',
+      params: {slug: 'slug.current'},
+      fallback: {slug: '_'},
+    })
+    await expect(generateStaticParams()).rejects.toThrow(
+      'expected the query to return an array, got object',
+    )
+  })
+})

--- a/packages/next-sanity/test/defineGenerateStaticParams.test.ts
+++ b/packages/next-sanity/test/defineGenerateStaticParams.test.ts
@@ -1,6 +1,6 @@
 import type {ClientConfig, SanityClient} from '@sanity/client'
 import {evaluate, parse} from 'groq-js'
-import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {defineGenerateStaticParams, type StaticParams} from 'next-sanity/static-params'
 import {describe, expect, expectTypeOf, test, vi} from 'vitest'
 
 const dataset = [
@@ -164,25 +164,28 @@ describe('definition-time validation', () => {
     ).toThrow(/`limit` must be a positive integer, got 0/)
   })
 
-  test.each([{slug: ''}, {path: []}, {path: ['']}, {path: ['ok', '']}, {category: 'ok', slug: ''}])(
-    'rejects the fallback %j at definition time',
-    (fallback) => {
-      const {client} = createFakeClient()
-      const key = Object.keys(fallback).at(-1)
-      expect(() =>
-        defineGenerateStaticParams({
-          client,
-          filter: '_type == "post"',
-          params: Object.fromEntries(Object.keys(fallback).map((name) => [name, 'slug.current'])),
-          fallback,
-        }),
-      ).toThrow(
-        new TypeError(
-          `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
-        ),
-      )
-    },
-  )
+  test.each<StaticParams>([
+    {slug: ''},
+    {path: []},
+    {path: ['']},
+    {path: ['ok', '']},
+    {category: 'ok', slug: ''},
+  ])('rejects the fallback %j at definition time', (fallback) => {
+    const {client} = createFakeClient()
+    const key = Object.keys(fallback).at(-1)
+    expect(() =>
+      defineGenerateStaticParams({
+        client,
+        filter: '_type == "post"',
+        params: Object.fromEntries(Object.keys(fallback).map((name) => [name, 'slug.current'])),
+        fallback,
+      }),
+    ).toThrow(
+      new TypeError(
+        `defineGenerateStaticParams: \`fallback.${key}\` must be a non-empty string or a non-empty array of non-empty strings`,
+      ),
+    )
+  })
 })
 
 describe('generateStaticParams', () => {

--- a/packages/next-sanity/test/ensureStaticParams.test.ts
+++ b/packages/next-sanity/test/ensureStaticParams.test.ts
@@ -1,0 +1,24 @@
+import {ensureStaticParams} from 'next-sanity/static-params'
+import {expect, expectTypeOf, test} from 'vitest'
+
+test('passes a non-empty list through untouched', () => {
+  const params = [{slug: 'a'}, {slug: 'b'}]
+  expect(ensureStaticParams(params, {slug: '_'})).toBe(params)
+})
+
+test('returns the fallback for an empty list, null, and undefined', () => {
+  const empty: {slug: string}[] = []
+  expect(ensureStaticParams(empty, {slug: '_'})).toEqual([{slug: '_'}])
+  expect(ensureStaticParams(null, {slug: '_'})).toEqual([{slug: '_'}])
+  expect(ensureStaticParams(undefined, {slug: '_'})).toEqual([{slug: '_'}])
+})
+
+test('infers the param shape from the list, not the fallback', () => {
+  const result = ensureStaticParams([{article: 'a', section: ['s']}], {
+    article: '_',
+    section: ['_'],
+  })
+  expectTypeOf(result).toEqualTypeOf<{article: string; section: string[]}[]>()
+  // @ts-expect-error the fallback must match the list's shape
+  ensureStaticParams([{article: 'a'}], {slug: '_'})
+})

--- a/packages/next-sanity/tsdown.config.ts
+++ b/packages/next-sanity/tsdown.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     './src/live/conditions/default/index.ts',
     './src/live/client-components/index.ts',
     './src/live/server-actions/index.ts',
+    './src/static-params/index.ts',
     './src/studio/client-component/index.ts',
     './src/studio/index.ts',
     './src/visual-editing/client-component/index.ts',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@repo/sanity-config':
         specifier: workspace:*
         version: link:../../packages/sanity-config
+      '@sanity/client':
+        specifier: 'catalog:'
+        version: 7.26.2
       '@sanity/image-url':
         specifier: 'catalog:'
         version: 2.1.1
@@ -14355,6 +14358,7 @@ snapshots:
     optionalDependencies:
       '@babel/runtime': 7.29.7
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+    optional: true
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)':
     dependencies:
@@ -14560,7 +14564,7 @@ snapshots:
   '@sanity/cli-build@6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.7)(sanity@6.13.0-next.7)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.10)(yaml@2.9.0)':
     dependencies:
       '@oclif/core': 4.13.3
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.1)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)
       '@sanity/cli-core': 3.6.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.10)(yaml@2.9.0)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/schema': 6.12.0(@types/react@19.2.18)(vitest@4.1.10)
@@ -16122,7 +16126,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.1)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)
 
   '@vitest/browser-playwright@4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)':
     dependencies:
@@ -16136,6 +16140,20 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.10(msw@2.15.0)(vite@8.2.1)(vitest@4.1.10)':
     dependencies:
@@ -16154,6 +16172,24 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -16166,9 +16202,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.1)(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -16187,6 +16223,15 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(msw@2.15.0)(vite@8.2.2)':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -17731,13 +17776,13 @@ snapshots:
     dependencies:
       undici: 7.29.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
 
   get-it@9.5.2(vitest@4.1.10):
     dependencies:
       undici: 7.29.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
 
   get-latest-version@6.0.1:
     dependencies:
@@ -21498,6 +21543,37 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
       '@vitest/browser-playwright': 4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      jsdom: 29.1.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       groq:
         specifier: ^6.12.0
         version: 6.12.0
+      groq-js:
+        specifier: ^2.0.0
+        version: 2.0.0
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1451,14 +1454,8 @@ packages:
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
 
-  '@codemirror/search@6.7.1':
-    resolution: {integrity: sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==}
-
   '@codemirror/search@6.7.2':
     resolution: {integrity: sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==}
-
-  '@codemirror/state@6.7.1':
-    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
 
   '@codemirror/state@6.7.2':
     resolution: {integrity: sha512-U3RiPX62Wl/Gx4ftQ7UxLlloSfsFTQqKa+7vFBYteZGCzkp6oBqcsD7iSwniWRGobCAmDcwZSY+Six3+3ztdfg==}
@@ -1468,9 +1465,6 @@ packages:
 
   '@codemirror/view@6.43.10':
     resolution: {integrity: sha512-vVWLvd4fKWYN/pMcwUrg6dWeublxmSz+V+52ZjW3h64IVN9cRUYLk5Km4JDT9vifxAFfDtNOIFxKYENthcolJQ==}
-
-  '@codemirror/view@6.43.9':
-    resolution: {integrity: sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -12127,21 +12121,11 @@ snapshots:
       '@codemirror/view': 6.43.10
       crelt: 1.0.7
 
-  '@codemirror/search@6.7.1':
-    dependencies:
-      '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.9
-      crelt: 1.0.7
-
   '@codemirror/search@6.7.2':
     dependencies:
       '@codemirror/state': 6.7.2
       '@codemirror/view': 6.43.10
       crelt: 1.0.7
-
-  '@codemirror/state@6.7.1':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.3
 
   '@codemirror/state@6.7.2':
     dependencies:
@@ -12150,20 +12134,13 @@ snapshots:
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
       '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.9
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.43.10':
     dependencies:
       '@codemirror/state': 6.7.2
-      crelt: 1.0.7
-      style-mod: 4.1.3
-      w3c-keyname: 2.2.8
-
-  '@codemirror/view@6.43.9':
-    dependencies:
-      '@codemirror/state': 6.7.1
       crelt: 1.0.7
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -14378,7 +14355,6 @@ snapshots:
     optionalDependencies:
       '@babel/runtime': 7.29.7
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-    optional: true
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)':
     dependencies:
@@ -14584,7 +14560,7 @@ snapshots:
   '@sanity/cli-build@6.2.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.7)(sanity@6.13.0-next.7)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.10)(yaml@2.9.0)':
     dependencies:
       '@oclif/core': 4.13.3
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.1)
       '@sanity/cli-core': 3.6.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.10)(yaml@2.9.0)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/schema': 6.12.0(@types/react@19.2.18)(vitest@4.1.10)
@@ -16146,7 +16122,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.2)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.7)(vite@8.2.1)
 
   '@vitest/browser-playwright@4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)':
     dependencies:
@@ -16160,20 +16136,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-
-  '@vitest/browser-playwright@4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.10)':
-    dependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
-      playwright: 1.62.1
-      tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
 
   '@vitest/browser@4.1.10(msw@2.15.0)(vite@8.2.1)(vitest@4.1.10)':
     dependencies:
@@ -16192,24 +16154,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
-      '@vitest/utils': 4.1.10
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
-      ws: 8.21.3
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -16222,9 +16166,9 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
     optionalDependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.2)(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(msw@2.15.0)(vite@8.2.1)(vitest@4.1.10)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -16243,15 +16187,6 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(msw@2.15.0)(vite@8.2.2)':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -16874,9 +16809,9 @@ snapshots:
       '@codemirror/commands': 6.11.0
       '@codemirror/language': 6.12.4
       '@codemirror/lint': 6.9.7
-      '@codemirror/search': 6.7.1
-      '@codemirror/state': 6.7.1
-      '@codemirror/view': 6.43.9
+      '@codemirror/search': 6.7.2
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
 
   color-convert@2.0.1:
     dependencies:
@@ -17796,13 +17731,13 @@ snapshots:
     dependencies:
       undici: 7.29.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
 
   get-it@9.5.2(vitest@4.1.10):
     dependencies:
       undici: 7.29.0
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2)
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.1)
 
   get-latest-version@6.0.1:
     dependencies:
@@ -21563,37 +21498,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
       '@vitest/browser-playwright': 4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.1)(vitest@4.1.10)
-      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
-      jsdom: 29.1.1(@noble/hashes@2.3.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0)(vite@8.2.2):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0)(vite@8.2.2)
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0)(playwright@1.62.1)(vite@8.2.2)(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:

--- a/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -11,7 +11,7 @@
 
 `generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
 
-`defineGenerateStaticParams` from `next-sanity/static-params` assembles the query from a GROQ filter and one GROQ expression per route param, parses every piece with `groq-js` when the module loads (a typo fails `next build` with the expression and position), fetches from the published perspective, and returns `[fallback]` instead of `[]`. Cache Components fails the build on an empty `generateStaticParams` result, so `fallback` is required and the page handles it with `notFound()`. The `fallback` shape types the result: a `string` value declares `[slug]`, a `string[]` value declares `[...slug]`.
+`defineGenerateStaticParams` from `next-sanity/static-params` assembles the query from a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the module loads, so a typo fails `next build` with the expression and its position. At build time it fetches from the published perspective and returns `[fallback]` instead of `[]`. Cache Components fails the build on an empty `generateStaticParams` result, so `fallback` is required and the page handles it with `notFound()`. The `fallback` shape types the result. A `string` value declares `[slug]` and a `string[]` value declares `[...slug]`.
 
 This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
 

--- a/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -11,6 +11,8 @@
 
 `generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
 
+`defineGenerateStaticParams` from `next-sanity/static-params` assembles the query from a GROQ filter and one GROQ expression per route param, parses every piece with `groq-js` when the module loads (a typo fails `next build` with the expression and position), fetches from the published perspective, and returns `[fallback]` instead of `[]`. Cache Components fails the build on an empty `generateStaticParams` result, so `fallback` is required and the page handles it with `notFound()`. The `fallback` shape types the result: a `string` value declares `[slug]`, a `string[]` value declares `[...slug]`.
+
 This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
 
 - Prerendered pages load instantly.
@@ -33,26 +35,26 @@ export default function Loading() {
 
 ```tsx
 // src/app/[slug]/page.tsx
-import {
-  cachedSanity,
-  getDynamicFetchOptions,
-  cachedSanityStaticParams,
-  type DynamicFetchOptions,
-} from '@/sanity/lib/live'
+import {cachedSanity, getDynamicFetchOptions, type DynamicFetchOptions} from '@/sanity/lib/live'
+import {client} from '@/sanity/lib/client'
 import {defineQuery} from 'next-sanity'
+import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {notFound} from 'next/navigation'
 
-export async function generateStaticParams() {
-  const pageSlugsQuery = defineQuery(
-    `*[_type == "page" && defined(slug.current)] | order(_updatedAt desc) [0...100]{"slug": slug.current}`,
-  )
-  const {data} = await cachedSanityStaticParams({query: pageSlugsQuery})
-  return data
-}
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "page" && defined(slug.current)',
+  params: {slug: 'slug.current'},
+  fallback: {slug: '__placeholder__'},
+  order: '_updatedAt desc',
+  limit: 100,
+})
 
 // With sibling `loading.tsx`, skip the `<Suspense>` + `DynamicPage` indirection: await `params`
 // and `getDynamicFetchOptions` directly inside `Page`.
 export default async function Page({params}: PageProps<'/[slug]'>) {
   const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
+  if (slug === '__placeholder__') notFound()
   return <CachedPage slug={slug} perspective={perspective} stega={stega} />
 }
 async function CachedPage({
@@ -68,6 +70,25 @@ async function CachedPage({
     stega,
   })
   return <article>{/* use `data` to render stuff */}</article>
+}
+```
+
+A nested segment such as `src/app/[category]/[slug]/page.tsx` receives the parent's params, and `defineGenerateStaticParams` forwards them to GROQ as variables:
+
+```tsx
+export const {generateStaticParams} = defineGenerateStaticParams({
+  client,
+  filter: '_type == "page" && category->slug.current == $category',
+  params: {slug: 'slug.current'},
+  fallback: {slug: '__placeholder__'},
+})
+```
+
+A root param with a constant value, such as `src/app/[perspective]/layout.tsx`, needs no helper. Return the constant, and Cache Components still gets its one required value:
+
+```ts
+export function generateStaticParams() {
+  return [{perspective: 'published'}]
 }
 ```
 

--- a/skills/sanity-live-cache-components/reference/dynamic-segments.md
+++ b/skills/sanity-live-cache-components/reference/dynamic-segments.md
@@ -11,7 +11,7 @@
 
 `generateStaticParams` returns only the 100 most recently updated pages. A sibling `loading.tsx` renders fallback UI, so `page.tsx` itself can skip the `<Suspense>` wrapper. The same fallback UI is reused in draft mode.
 
-`defineGenerateStaticParams` from `next-sanity/static-params` assembles the query from a GROQ filter and one GROQ expression per route param. It parses every piece with `groq-js` when the module loads, so a typo fails `next build` with the expression and its position. At build time it fetches from the published perspective and returns `[fallback]` instead of `[]`. Cache Components fails the build on an empty `generateStaticParams` result, so `fallback` is required and the page handles it with `notFound()`. The `fallback` shape types the result. A `string` value declares `[slug]` and a `string[]` value declares `[...slug]`.
+`defineGenerateStaticParams` from `next-sanity/static-params` reads the page's own GROQ query. Each `<expression> == $param` conjunct in the root `*[...]` filter becomes a route param, the other conjuncts stay as constraints, and the `[0]` and projection are dropped. `groq-js` parses the query when the module loads, so a typo or an unbound `$param` fails `next build` with the offending expression. At build time it fetches from the published perspective and returns `[{slug: STATIC_PARAMS_PLACEHOLDER}]` instead of `[]`. Cache Components fails the build on an empty result. The [Next.js error page](https://nextjs.org/docs/messages/empty-generate-static-params) names this placeholder as the fallback and warns that it only validates the `notFound()` path, so the helper uses it only when the query returns nothing. The page handles the placeholder with `notFound()`.
 
 This scales to thousands of pages without ballooning `next build` and without compromising UX in production:
 
@@ -38,14 +38,14 @@ export default function Loading() {
 import {cachedSanity, getDynamicFetchOptions, type DynamicFetchOptions} from '@/sanity/lib/live'
 import {client} from '@/sanity/lib/client'
 import {defineQuery} from 'next-sanity'
-import {defineGenerateStaticParams} from 'next-sanity/static-params'
+import {defineGenerateStaticParams, STATIC_PARAMS_PLACEHOLDER} from 'next-sanity/static-params'
 import {notFound} from 'next/navigation'
+
+const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
 
 export const {generateStaticParams} = defineGenerateStaticParams({
   client,
-  filter: '_type == "page" && defined(slug.current)',
-  params: {slug: 'slug.current'},
-  fallback: {slug: '__placeholder__'},
+  query: pageQuery,
   order: '_updatedAt desc',
   limit: 100,
 })
@@ -54,7 +54,7 @@ export const {generateStaticParams} = defineGenerateStaticParams({
 // and `getDynamicFetchOptions` directly inside `Page`.
 export default async function Page({params}: PageProps<'/[slug]'>) {
   const [{slug}, {perspective, stega}] = await Promise.all([params, getDynamicFetchOptions()])
-  if (slug === '__placeholder__') notFound()
+  if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()
   return <CachedPage slug={slug} perspective={perspective} stega={stega} />
 }
 async function CachedPage({
@@ -62,7 +62,6 @@ async function CachedPage({
   perspective,
   stega,
 }: Awaited<PageProps<'/[slug]'>['params']> & DynamicFetchOptions) {
-  const pageQuery = defineQuery(`*[_type == "page" && slug.current == $slug][0]`)
   const {data} = await cachedSanity({
     query: pageQuery,
     params: {slug},
@@ -73,14 +72,25 @@ async function CachedPage({
 }
 ```
 
-A nested segment such as `src/app/[category]/[slug]/page.tsx` receives the parent's params, and `defineGenerateStaticParams` forwards them to GROQ as variables:
+A nested segment such as `src/app/[category]/[slug]/page.tsx` receives the parent's params. A binding the parent already provides becomes a GROQ constraint and is left out of the result, so this query yields `{slug}[]` when Next.js calls `generateStaticParams({params: {category}})`:
 
 ```tsx
+const pageQuery = defineQuery(
+  `*[_type == "page" && category->slug.current == $category && slug.current == $slug][0]`,
+)
+
+export const {generateStaticParams} = defineGenerateStaticParams({client, query: pageQuery})
+```
+
+A catch-all segment such as `src/app/docs/[...path]/page.tsx` needs a `fallback`, because the query cannot tell `[slug]` from `[...slug]`. A `string[]` value declares the catch-all:
+
+```tsx
+const docQuery = defineQuery(`*[_type == "doc" && string::split(slug.current, "/") == $path][0]`)
+
 export const {generateStaticParams} = defineGenerateStaticParams({
   client,
-  filter: '_type == "page" && category->slug.current == $category',
-  params: {slug: 'slug.current'},
-  fallback: {slug: '__placeholder__'},
+  query: docQuery,
+  fallback: {path: [STATIC_PARAMS_PLACEHOLDER]},
 })
 ```
 

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,10 @@
     "build": {
       "dependsOn": ["^build"]
     },
-    "typegen": {},
+    "typegen": {
+      "inputs": ["$TURBO_DEFAULT$", "!sanity.types.ts"],
+      "outputs": [".next/types/**", "sanity.types.ts", "next-env.d.ts"]
+    },
     "test": {
       "dependsOn": ["^build"],
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -6,8 +6,7 @@
       "dependsOn": ["^build"]
     },
     "typegen": {
-      "inputs": ["$TURBO_DEFAULT$", "!sanity.types.ts"],
-      "outputs": [".next/types/**", "sanity.types.ts", "next-env.d.ts"]
+      "cache": false
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Cache Components fails `next build` when `generateStaticParams` returns `[]`. Every app that lists slugs from Sanity has to remember the placeholder fallback, and a typo in the GROQ that lists those slugs surfaces as a network error deep in the build. The first version of this PR fixed that with a `filter` plus one GROQ expression per param, which meant the same document type and slug path were spelled twice, once in the page query and once in `generateStaticParams`. The user asked for the page query to be the only input:

```ts
const postQuery = defineQuery(
  `*[_type == "post" && slug.current == $slug][0]{title, "slug": slug.current, publishedAt}`,
)
export const {generateStaticParams} = defineGenerateStaticParams({
  client,
  query: postQuery,
})
```

`defineGenerateStaticParams` now parses that query with `groq-js` when the route module loads and derives `*[_type == "post" && defined(slug.current)]{"slug": slug.current}` from it. `$slug` is a param because a conjunct compares something to it with `==`. `slug.current` is the path because it is the other side of that `==`. `_type == "post"` stays because it binds nothing. The `[0]` and the projection are dropped. `ensureStaticParams` is unchanged.

## Scope

- `packages/next-sanity/src/static-params/index.ts`. `defineGenerateStaticParams<Shape = Record<string, string>>({client, query, order?, limit?, fallback?})`. The `filter` and `params` options are gone. New export `STATIC_PARAMS_PLACEHOLDER = '__placeholder__'` so pages write `if (slug === STATIC_PARAMS_PLACEHOLDER) notFound()`.
- Inference rules, all applied to the root `*[...]` filter after splitting on top-level `&&` (parentheses around a comparison or an `&&` are unwrapped, `*[A][B]` is read as `*[A && B]`):
  - A conjunct `<expression> == $param` or `$param == <expression>` is a binding. The expression may be a path, a dereference, or a function call.
  - Every other conjunct is kept as a constraint, re-printed by `groq-js` `unparse`, so `defined(x)` appears as `global::defined(x)` and `a->b` as `a->.b`. The re-printed text parses back to an identical AST (23 probe queries, 0 diffs).
  - Params outside the root filter, for example `$slug` inside a related-posts subquery in the projection, are ignored because that part of the query is dropped.
- Parent params at call time. Next.js calls `generateStaticParams({params})` with the parent segment's params. A binding whose param the parent provides becomes the constraint `<expression> == $param`, passed as a GROQ param, and is not projected. The rest are generated. `app/[category]/[slug]/page.tsx` yields `{slug}[]` when called with `{params: {category}}` and `{category, slug}[]` when called without.
- Errors at module load, each naming the offending GROQ:
  - Syntax error, with position and the `GroqSyntaxError` as `cause`.
  - A `$param` in the root filter that is not bound with `==` in a top-level `&&`. This covers `match`, `references($ref)`, and an `||` around the binding.
  - `$a == $b`.
  - The same `$param` bound twice.
  - No bindings at all.
  - A query that does not start with `*[...]`, including a filter after a projection.
  - `fallback` keys that name no bound param, `fallback` values that are empty, `limit` below 1, an `order` that does not parse.
- At call time, an error when the parent params already bind every `$param`.
- `fallback` is optional. The default is `STATIC_PARAMS_PLACEHOLDER` for each generated param. It stays as the way to declare a catch-all, `fallback: {path: [STATIC_PARAMS_PLACEHOLDER]}`, since the query cannot tell `[slug]` from `[...slug]`. It also types the result through inference.
- The placeholder follows the Next.js guidance in the [`empty-generate-static-params`](https://nextjs.org/docs/messages/empty-generate-static-params) message: a placeholder only validates the `notFound()` path, so real values are emitted whenever the query returns any and the placeholder is used only when it returns nothing.
- `apps/mvp/app/(website)/posts/[slug]/page.tsx` and `apps/static/app/posts/[slug]/page.tsx` use the two-line form and the placeholder constant.
- README section, `skills/sanity-live-cache-components/reference/dynamic-segments.md`, TSDoc, and `.changeset/generate-static-params.md` rewritten for the new API, with the Next.js placeholder guidance and its link.
- `src/__tests__/exports.spec.ts` snapshot gains one line, `STATIC_PARAMS_PLACEHOLDER: string`.
- Earlier commits on this branch: `apps/mvp`'s `typegen` script now runs `next typegen` first so the `PageProps` global exists before CI lint, and `turbo.json` runs `typegen` uncached after a Bugbot finding showed a schema-only change in `@repo/sanity-config` could restore stale types from the cache.

## Tradeoffs

- Re-printed constraints instead of source text. The public groq-js AST carries no source spans, so the kept conjuncts come from `unparse`. The assembled `query` string reads `global::defined(publishedAt)` where the page wrote `defined(publishedAt)`. Semantics are identical and the tests execute the assembled query with `groq-js` `evaluate` over an in-memory dataset.
- Local AST types. groq-js 2.0.0 publishes `index.d.ts` files that import from `./shared-*.js` declarations that are not in the tarball, so `ExprNode` and friends resolve to `any`. The module declares the five node shapes it inspects (`Filter`, `And`, `Group`, `OpCall`, `Parameter`) and treats everything else as an opaque subtree. Worth reporting upstream.
- Catch-all kind is not inferred. The query says nothing about whether `$path` is a string or an array, so a `[...path]` route must pass a `string[]` fallback. An explicit `Shape` generic with an array-valued key and no fallback compiles but drops every row at runtime. The TSDoc says so.
- Params inside the projection are not validated. They are dropped with the projection, so a `$locale` used only there never reaches the static params query. A page that needs `$locale` in the root filter for prerendering has to put it there.
- `inferStaticParamsQuery` stays internal. The tests reach it through the returned `query` string. One less export to maintain.
- One `no-unsafe-type-assertion` suppression at the return of `generateStaticParams`. `Shape` is the caller's claim about the route, the runtime validates kinds against the fallback sample, and that is the one place the two meet.
- `groq-js@2.0.0` requires Node `>=22.12`. `next-sanity` on `next` still allows `>=20.19 <22` until [#3940](https://github.com/sanity-io/next-sanity/pull/3940) raises engines to `>=22.12`, which closes the gap when both land.

## Blast Radius

- `next-sanity/static-params` is new in this PR, so the API change from `filter`/`params` to `query` breaks no released code.
- `groq-js` remains a runtime dependency of the `static-params` entry point only. Nothing under `next-sanity/live` or any Client Component path imports it.
- Both demo apps change one file each. When [#3945](https://github.com/sanity-io/next-sanity/pull/3945) lands, the `apps/mvp` route moves under `app/[perspective]/`; the integration branch `cursor/next-integration-3348` shows the moved file.
- `pnpm typegen` runs uncached, about 15 seconds for both apps.

## Verification

All from the unit worktree with the nvm Node 22.22.2 on `PATH`, at `81cc4cc0`.

- `pnpm build --filter=./packages/*` ok, publint no issues.
- `pnpm typegen` ok, no content change in either `sanity.types.ts` after `oxfmt`.
- `pnpm lint` (type-aware oxlint, warnings denied) ok.
- `pnpm knip` ok.
- `CI=true pnpm test` 14 files, 222 passed, 12 skipped. `test/defineGenerateStaticParams.test.ts` has 44 tests. They were committed first (`7348cca5`) and all 43 of the initial set failed against the old API before the implementation landed (`82fb9ddd`).
- `pnpm --filter mvp build` with `.env.local` set to `pv8y60vp/production`:

```
Route (app)                  Revalidate  Expire
┌ ○ /                                1y      1y
├ ○ /_not-found
├ ƒ /api/draft-mode/enable
├ ○ /no-resolve-perspective          1y      1y
├ ○ /only-production                 1y      1y
├ ○ /only-visual-editing             1y      1y
├   /posts/[slug]
│ ├ ◐ /posts/[slug]
│ ├ ○ /posts/aliens-2                1y      1y
│ ├ ○ /posts/prometheus              1y      1y
│ └ ◐ [+2 more paths]
└ ○ /studio
```

`.next/server/app/posts/` holds `aliens.html`, `aliens-2.html`, `prometheus.html`, `test.html`.

- `pnpm --filter static build`:

```
Route (app)
┌ ○ /
├ ○ /_not-found
├   /posts/[slug]
│ ├ ● /posts/test
│ ├ ● /posts/prometheus
│ ├ ● /posts/aliens
│ └ ● /posts/aliens-2
└ ○ /studio
```

- The turbo change was proven with a probe field added to `packages/sanity-config/src/schemas/post.ts`: before, `pnpm typegen` hit the cache and the field never reached `sanity.types.ts`; after, two consecutive runs both executed and the field appeared, and `rm -rf apps/*/.next && pnpm typegen && pnpm lint` exits 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e8836c5-bb26-4295-9429-41afac413348?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e8836c5-bb26-4295-9429-41afac413348&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

