### PR TITLE
feat(visual-editing)!: remove the deprecated history prop from VisualEditingProps

### DIFF
--- a/.changeset/drop-deprecated.md
+++ b/.changeset/drop-deprecated.md
@@ -1,0 +1,28 @@
+---
+"next-sanity": major
+---
+
+feat(visual-editing)!: remove the deprecated `history` prop from `VisualEditingProps`
+
+`<VisualEditing />` from `next-sanity/visual-editing` implements the history adapter for the Next.js App Router itself, and the `history` prop has been typed `never` and marked `@deprecated` for several major versions. The prop is now gone from `VisualEditingProps`.
+
+Before, passing `history` was a type error against `never`:
+
+```tsx
+import {VisualEditing} from "next-sanity/visual-editing"
+
+// Type error: `history` is `never`
+;<VisualEditing history={myHistoryAdapter} />
+```
+
+After, passing `history` is an excess property error, and there is nothing to migrate. Drop the prop if you still spell it out:
+
+```tsx
+import {VisualEditing} from "next-sanity/visual-editing"
+
+;<VisualEditing />
+```
+
+The runtime behavior is unchanged. `<VisualEditing />` keeps wiring `next/navigation` into the `@sanity/visual-editing` history adapter for you.
+
+This is the only API in `next-sanity` v13 that carried an `@deprecated` marker outside of `next-sanity/studio`, which is removed in a separate change.

--- a/.changeset/drop-deprecated.md
+++ b/.changeset/drop-deprecated.md
@@ -4,7 +4,7 @@
 
 feat(visual-editing)!: remove the deprecated `history` prop from `VisualEditingProps`
 
-`<VisualEditing />` from `next-sanity/visual-editing` implements the history adapter for the Next.js App Router itself, and the `history` prop has been typed `never` and marked `@deprecated` for several major versions. The prop is now gone from `VisualEditingProps`.
+`<VisualEditing />` from `next-sanity/visual-editing` implements the history adapter for the Next.js App Router itself. The `history` prop was typed `never` and marked `@deprecated` for several major versions. It is now gone from `VisualEditingProps`.
 
 Before, passing `history` was a type error against `never`:
 
@@ -15,7 +15,7 @@ import {VisualEditing} from "next-sanity/visual-editing"
 ;<VisualEditing history={myHistoryAdapter} />
 ```
 
-After, passing `history` is an excess property error, and there is nothing to migrate. Drop the prop if you still spell it out:
+After, passing `history` is an excess property error. There is nothing to migrate. Drop the prop if you still spell it out:
 
 ```tsx
 import {VisualEditing} from "next-sanity/visual-editing"

--- a/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
+++ b/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx
@@ -15,10 +15,6 @@ import {addPathPrefix, normalizePathTrailingSlash, removePathPrefix} from './uti
  */
 export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'> {
   /**
-   * @deprecated The histoy adapter is already implemented
-   */
-  history?: never
-  /**
    * If next.config.ts is configured with a basePath we try to configure it automatically,
    * you can disable this by setting basePath to ''.
    * @example basePath="/my-custom-base-path"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

v14 drops every API that v13 already marks `@deprecated`. The honest inventory for `next-sanity`, excluding `next-sanity/studio` (removed in its own PR), is one symbol. `VisualEditingProps.history` has been typed `never` with an `@deprecated` note since the component started implementing the Next.js history adapter itself. Nothing else in `src/`, the README, or the migration guides carries a deprecation marker. The `console.warn` sites in `defineLive`, `SanityLive`, and `revalidateSyncTagsAction` are runtime hints about missing tokens and draft mode, not deprecations, so they stay.

## Scope

- `packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx`. Remove `history?: never` and its `@deprecated` TSDoc from `VisualEditingProps`. The interface already extends `Omit<VisualEditingOptions, 'history'>`, so `history` stays unaccepted. The replacement is nothing. `<VisualEditing />` wires `next/navigation` into the `@sanity/visual-editing` adapter for you.
- `.changeset/drop-deprecated.md`. `'next-sanity': major` with the before and after snippet.

Out of scope. `next-sanity/studio` (the sibling studio removal PR), `src/live/**` redesign, and dependency ranges.

The exports snapshot in `src/__tests__/exports.spec.ts` is unchanged because no export name changed. `apps/mvp` and `apps/static` never passed `history`, so they need no edits.

## Tradeoffs

Passing `history` was a type error against `never`. It is now an excess property error. Both fail at compile time, so no consumer that compiled on v13 breaks on this change.

## Blast Radius

Type-only. The emitted JavaScript for `next-sanity/visual-editing` is identical. Only `.d.ts` consumers see the change, and only if they spelled out the `history` prop, which never type checked.

## Verification

Run from the unit worktree with the nvm Node 22.22.2 on `PATH`.

- `pnpm build --filter=./packages/*`. `next-sanity:build: ✔ Build complete in 591ms`, `[publint] No issues found`.
- `pnpm typegen`. `Tasks: 4 successful, 4 total` with `NEXT_PUBLIC_SANITY_PROJECT_ID=pv8y60vp` and `NEXT_PUBLIC_SANITY_DATASET=production` set for both apps. Without the env the `mvp#typegen` task fails with `Invalid studio config format`, on `origin/next` too. The generated `sanity.types.ts` diff is formatting-only drift from the generator and was reverted, not committed.
- `pnpm lint`. `oxlint --type-check --type-aware --report-unused-disable-directives --deny-warnings` exited 0 with no findings.
- `pnpm knip`. Exited 0 with no findings.
- `CI=true pnpm test`. `next-sanity:test: Test Files 12 passed (12)`, `Tests 175 passed | 12 skipped (187)`. Fixtures `Tasks: 4 successful, 4 total`.
- `pnpm playwright install chromium` then `pnpm --filter next-sanity test:e2e`. `Test Files 1 passed (1)`, `Tests 25 passed (25)`. The `SanityLiveClientComponent` error logs in the output are the error-boundary tests doing their job.
- App builds skipped. No file under `apps/` changed and neither app passes `history` to `<VisualEditing />`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e8836c5-bb26-4295-9429-41afac413348?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e8836c5-bb26-4295-9429-41afac413348&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

